### PR TITLE
Coverage Settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   # unit tests
   - pytest
   # test covarege
-  - coverage run -m unittest discover -p "*_test.py"
+  - coverage run -m pytest
 
 after_success:
   - codecov


### PR DESCRIPTION
This PR

- Adds YAML for code coverage. We can use this file to configure our coverage on https://codecov.io/

- Uses `pytest` to generate coverage report instead of `unittest`. There was a bug in the discover pattern used for `unittest`. Hence choosing `pytest` for simplicity.