### PR TITLE
Fix a bug in StanfordProcessor

### DIFF
--- a/forte/processors/stanfordnlp_processor.py
+++ b/forte/processors/stanfordnlp_processor.py
@@ -97,8 +97,8 @@ class StandfordNLPProcessor(PackProcessor):
                     if "lemma" in self.processors:
                         token.set_fields(lemma=word.lemma)
 
+                    token = input_pack.add_or_get_entry(token)
                     tokens.append(token)
-                    input_pack.add_or_get_entry(token)
 
             # For each sentence, get the dependency relations among tokens
             if "depparse" in self.processors:


### PR DESCRIPTION
This PR

- Fixed a bug. We now get the token from `add_or_get_entry()` before appending to `tokens`. This fixes the issue when the datapack already contains the tokens, we would like to operate on the existing token.