### PR TITLE
Use torch.load and map_location to load the weights

### DIFF
--- a/forte/processors/ner_predictor.py
+++ b/forte/processors/ner_predictor.py
@@ -15,7 +15,6 @@
 # pylint: disable=logging-fstring-interpolation
 import logging
 import os
-import pickle
 from typing import Dict, List, Optional, Tuple, Type
 
 import numpy as np

--- a/forte/processors/ner_predictor.py
+++ b/forte/processors/ner_predictor.py
@@ -111,7 +111,7 @@ class CoNLLNERPredictor(FixedSizeBatchProcessor):
 
                 if os.path.exists(path):
                     with open(path, "rb") as f:
-                        weights = pickle.load(f)
+                        weights = torch.load(f, map_location=self.device)
                         model.load_state_dict(weights)
                 return model
 


### PR DESCRIPTION
This PR fixes

- An issue while loading model weights. We now use `torch.load` instead of `pickle.load` to load weights.