### PR TITLE
Auto add entries to pack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
         # build documents
         - sphinx-build -W -b html -d _build/doctrees . _build/html
         # check for typos
-        - sphinx-build -W -b spelling -d _build/doctrees . _build/spelling
+        - sphinx-build -b spelling -d _build/doctrees . _build/spelling
 
 notifications:
   email: false

--- a/data_samples/random_texts/0.txt
+++ b/data_samples/random_texts/0.txt
@@ -1,7 +1,7 @@
-All you need to do is pick up the pen and begin.
-The knives were out and she was sharpening hers.
-So long and thanks for the fish.
-Rock music approaches at high velocity.
+1. All you need to do is pick up the pen and begin.
+2. The knives were out and she was sharpening hers.
+3. So long and thanks for the fish.
+4. Rock music approaches at high velocity.
 He didn't heed the warning and it had turned out surprisingly well.
 She advised him to come back at once.
 A glittering gem is not enough.

--- a/examples/chatbot/chatbot_example.py
+++ b/examples/chatbot/chatbot_example.py
@@ -26,50 +26,51 @@ from forte.processors.ir import SearchProcessor, BertBasedQueryCreator
 from forte.data.selector import NameMatchSelector
 from forte.processors.nltk_processors import (
     NLTKSentenceSegmenter, NLTKWordTokenizer, NLTKPOSTagger)
-
 from ft.onto.base_ontology import PredicateLink, Sentence
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
-def main():
-    config = yaml.safe_load(open("config.yml", "r"))
-    config = Config(config, default_hparams=None)
-
+def setup(config: Config) -> Pipeline:
     resource = Resources()
     query_pipeline = Pipeline[MultiPack](resource=resource)
     query_pipeline.set_reader(
         reader=MultiPackTerminalReader(), config=config.reader)
-
     query_pipeline.add(
         component=MicrosoftBingTranslator(), config=config.translator)
     query_pipeline.add(
         component=BertBasedQueryCreator(), config=config.query_creator)
     query_pipeline.add(
-        component=SearchProcessor(), config=config.indexer)
+        component=SearchProcessor(), config=config.searcher)
+
+    top_response_pack_name = config.indexer.response_pack_name + '_0'
+
     query_pipeline.add(
         component=NLTKSentenceSegmenter(),
-        selector=NameMatchSelector(
-            select_name=config.indexer.response_pack_name[0]))
+        selector=NameMatchSelector(select_name=top_response_pack_name))
     query_pipeline.add(
         component=NLTKWordTokenizer(),
-        selector=NameMatchSelector(
-            select_name=config.indexer.response_pack_name[0]))
+        selector=NameMatchSelector(select_name=top_response_pack_name))
     query_pipeline.add(
         component=NLTKPOSTagger(),
-        selector=NameMatchSelector(
-            select_name=config.indexer.response_pack_name[0]))
+        selector=NameMatchSelector(select_name=top_response_pack_name))
     query_pipeline.add(
         component=SRLPredictor(), config=config.SRL,
-        selector=NameMatchSelector(
-            select_name=config.indexer.response_pack_name[0]))
+        selector=NameMatchSelector(select_name=top_response_pack_name))
     query_pipeline.add(
         component=MicrosoftBingTranslator(), config=config.back_translator)
 
     query_pipeline.initialize()
 
-    for m_pack in query_pipeline.process_dataset():
+    return query_pipeline
 
+
+def main(config: Config):
+    query_pipeline = setup(config)
+    resource = query_pipeline.resource
+
+    m_pack: MultiPack
+    for m_pack in query_pipeline.process_dataset():
         # update resource to be used in the next conversation
         query_pack = m_pack.get_pack(config.translator.in_pack_name)
         if resource.get("user_utterance"):
@@ -87,7 +88,9 @@ def main():
         english_pack = m_pack.get_pack("pack")
         print(colored("English Translation of the query: ", "green"),
               english_pack.text, "\n")
-        pack = m_pack.get_pack(config.indexer.response_pack_name[0])
+
+        # Just take the first pack.
+        pack = m_pack.get_pack(config.indexer.response_pack_name_prefix + '_0')
         print(colored("Retrieved Document", "green"), pack.text, "\n")
         print(colored("German Translation", "green"),
               m_pack.get_pack("response").text, "\n")
@@ -99,7 +102,8 @@ def main():
             for link in pack.get(PredicateLink, sentence):
                 parent = link.get_parent()
                 child = link.get_child()
-                print(f"  - \"{child.text}\" is role {link.arg_type} of "
+                print(f"  - \"{child.text}\" is role "  # type: ignore
+                      f"{link.arg_type} of "
                       f"predicate \"{parent.text}\"")
             print()
 
@@ -107,4 +111,5 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    all_config = Config(yaml.safe_load(open("config.yml", "r")), None)
+    main(all_config)

--- a/examples/chatbot/config.yml
+++ b/examples/chatbot/config.yml
@@ -15,13 +15,16 @@ query_creator:
   max_seq_length: 128
   query_pack_name: "pack"
 
+searcher:
+  model_dir: "model/chatbot"
+  response_pack_name_prefix: "doc"
+
 indexer:
   batch_size: 128
   model_dir: "model/chatbot"
   k: 1
   query_pack_name: "pack"
-  response_pack_name:
-    - "doc_0"
+  response_pack_name_prefix: "doc"
 
 SRL:
   storage_path: "model/srl"

--- a/examples/passage_ranker/indexer_reranker_inference_pipeline.py
+++ b/examples/passage_ranker/indexer_reranker_inference_pipeline.py
@@ -33,8 +33,6 @@ if __name__ == "__main__":
     data_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                              config.data.relative_path)
 
-    doc_pack_name = config.indexer.response_pack_name_prefix
-
     nlp: Pipeline[MultiPack] = Pipeline()
     nlp.set_reader(reader=MultiPackTerminalReader(), config=config.reader)
 

--- a/examples/passage_ranker/reader.py
+++ b/examples/passage_ranker/reader.py
@@ -48,8 +48,7 @@ class EvalReader(MultiPackReader):
         data_pack.doc_id = fields[0]
         data_pack.set_text(fields[1])
 
-        document = Document(pack=data_pack, begin=0, end=len(fields[1]))
-        data_pack.add_entry(document)
+        Document(pack=data_pack, begin=0, end=len(fields[1]))
 
         yield multi_pack
 

--- a/examples/passage_ranker/reader.py
+++ b/examples/passage_ranker/reader.py
@@ -16,7 +16,6 @@ from typing import Iterator
 
 from forte.common.configuration import Config
 from forte.common.resources import Resources
-from forte.data.data_pack import DataPack
 from forte.data.multi_pack import MultiPack
 from forte.data.readers.base_reader import MultiPackReader
 from ft.onto.base_ontology import Document
@@ -42,16 +41,20 @@ class EvalReader(MultiPackReader):
 
     def _parse_pack(self, data_source: str) -> Iterator[MultiPack]:
         fields = data_source.split("\t")
-        data_pack = DataPack(doc_id=fields[0])
         multi_pack = MultiPack()
+
+        data_pack = multi_pack.add_pack(self.config.pack_name)
+
+        data_pack.doc_id = fields[0]
+        data_pack.set_text(fields[1])
+
         document = Document(pack=data_pack, begin=0, end=len(fields[1]))
         data_pack.add_entry(document)
-        data_pack.set_text(fields[1])
-        multi_pack.update_pack({self.config.pack_name: data_pack})
+
         yield multi_pack
 
-    @staticmethod
-    def default_configs():
+    @classmethod
+    def default_configs(cls):
         return {
             "pack_name": "query"
         }

--- a/examples/serialization/serialize_example.py
+++ b/examples/serialization/serialize_example.py
@@ -44,9 +44,7 @@ class PackCopier(MultiPackProcessor):
 
         ent: EntityMention
         for ent in from_pack.get_entries(EntityMention):
-            copy_pack.add_entry(
-                EntityMention(copy_pack, ent.begin, ent.end)
-            )
+            EntityMention(copy_pack, ent.begin, ent.end)
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:

--- a/examples/serialization/serialize_example.py
+++ b/examples/serialization/serialize_example.py
@@ -32,23 +32,21 @@ class PackCopier(MultiPackProcessor):
     """
 
     def _process(self, input_pack: MultiPack):
-        copy_pack: DataPack = DataPack()
         from_pack: DataPack = input_pack.get_pack(self.configs.copy_from)
+        copy_pack: DataPack = input_pack.add_pack(self.configs.copy_to)
 
         copy_pack.set_text(from_pack.text)
 
-        if from_pack.meta.doc_id is not None:
-            copy_pack.meta.doc_id = from_pack.meta.doc_id + '_copy'
+        if from_pack.doc_id is not None:
+            copy_pack.doc_id = from_pack.doc_id + '_copy'
         else:
-            copy_pack.meta.doc_id = 'copy'
+            copy_pack.doc_id = 'copy'
 
         ent: EntityMention
         for ent in from_pack.get_entries(EntityMention):
             copy_pack.add_entry(
                 EntityMention(copy_pack, ent.begin, ent.end)
             )
-
-        input_pack.add_pack(copy_pack, self.configs.copy_to)
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:

--- a/forte/data/base_pack.py
+++ b/forte/data/base_pack.py
@@ -247,8 +247,8 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
     def record_new_entry(self, entry: EntryType):
         """
         Call this when adding a new entry, will be called
-        in :class:`~forte.data.ontology.core.Entry` during
-        its init time.
+        in :class:`~forte.data.ontology.core.Entry` when
+        its `__init__` function is called.
 
         Args:
             entry: The entry to be added.

--- a/forte/data/base_pack.py
+++ b/forte/data/base_pack.py
@@ -184,27 +184,27 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
         """
         return self.add_entry(entry).tid
 
-    @abstractmethod
-    def add_or_get_entry(self, entry: EntryType) -> EntryType:
-        r"""Try to add an :class:`~forte.data.ontology.top.Entry` object to the
-        :class:`BasePack` object.
-
-        If a same entry already exists, will return the existing entry
-        instead of adding the new one. Note that we regard two entries as the
-        same if their :meth:`~forte.data.ontology.top.Entry.eq` have
-        the same return value, and users could
-        override :meth:`~forte.data.ontology.top.Entry.eq` in their
-        custom entry classes.
-
-        Args:
-            entry (Entry): An :class:`~forte.data.ontology.top.Entry`
-                object to be added to the pack.
-
-        Returns:
-            If a same entry already exists, returns the existing
-            entry. Otherwise, return the (input) entry just added.
-        """
-        raise NotImplementedError
+# @abstractmethod
+# def add_or_get_entry(self, entry: EntryType) -> EntryType:
+#     r"""Try to add an :class:`~forte.data.ontology.top.Entry` object to the
+#     :class:`BasePack` object.
+#
+#     If a same entry already exists, will return the existing entry
+#     instead of adding the new one. Note that we regard two entries as the
+#     same if their :meth:`~forte.data.ontology.top.Entry.eq` have
+#     the same return value, and users could
+#     override :meth:`~forte.data.ontology.top.Entry.eq` in their
+#     custom entry classes.
+#
+#     Args:
+#         entry (Entry): An :class:`~forte.data.ontology.top.Entry`
+#             object to be added to the pack.
+#
+#     Returns:
+#         If a same entry already exists, returns the existing
+#         entry. Otherwise, return the (input) entry just added.
+#     """
+#     raise NotImplementedError
 
     def add_all_remaining_entries(self):
         """

--- a/forte/data/base_pack.py
+++ b/forte/data/base_pack.py
@@ -113,6 +113,23 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
     def __iter__(self) -> Iterator[EntryType]:
         raise NotImplementedError
 
+    @property
+    def doc_id(self):
+        return self.meta.doc_id
+
+    @doc_id.setter
+    def doc_id(self, doc_id: str):
+        """
+        Update the doc id of this pack.
+
+        Args:
+            doc_id: The new doc id.
+
+        Returns:
+
+        """
+        self.meta.doc_id = doc_id
+
     @abstractmethod
     def delete_entry(self, entry: EntryType):
         r""" Remove the entry from the pack.

--- a/forte/data/base_pack.py
+++ b/forte/data/base_pack.py
@@ -102,12 +102,14 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
         state.pop('index')
         state.pop('_pack_manager')
         state.pop('_pending_entries')
+        state.pop('_BasePack__control_component')
         return state
 
     def __setstate__(self, state):
         super().__setstate__(state)
         self.__dict__['_pack_manager'] = PackManager()
         self.__dict__['_pending_entries'] = {}
+        self.__control_component: Optional[str] = None
 
     def set_meta(self, **kwargs):
         for k, v in kwargs.items():
@@ -212,7 +214,6 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
         Returns:
 
         """
-        print('calling add all entries')
         for entry, _ in list(self._pending_entries.values()):
             self.add_entry(entry)
         self._pending_entries.clear()

--- a/forte/data/base_pack.py
+++ b/forte/data/base_pack.py
@@ -15,7 +15,8 @@
 import copy
 import logging
 from abc import abstractmethod
-from typing import List, Optional, Set, Type, TypeVar, Union, Iterator, Dict
+from typing import List, Optional, Set, Type, TypeVar, Union, Iterator, Dict, \
+    Tuple
 
 import jsonpickle
 from forte.common import ProcessExecutionException
@@ -94,7 +95,7 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
 
         self.__control_component: Optional[str] = None
 
-        self._un_added_entries: Dict[int, Entry] = {}
+        self._un_added_entries: Dict[int, Tuple[Entry, str]] = {}
 
     def __getstate__(self):
         state = super().__getstate__()
@@ -119,7 +120,8 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
     def __del__(self):
         if len(self._un_added_entries) > 0:
             raise ProcessExecutionException(
-                "There are entries not added to the index correctly.")
+                f"There are {len(self._un_added_entries)} "
+                f"entries not added to the index correctly.")
 
     @property
     def doc_id(self):
@@ -200,7 +202,7 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
         """
         raise NotImplementedError
 
-    def add_all_remaining_entry(self):
+    def add_all_remaining_entries(self):
         """
         Calling this function will add the entries that are not added to the
         pack manually.
@@ -208,8 +210,9 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
         Returns:
 
         """
-        for entry in list(self._un_added_entries.values()):
+        for entry, _ in list(self._un_added_entries.values()):
             self.add_entry(entry)
+
         self._un_added_entries.clear()
 
     def serialize(self) -> str:
@@ -249,19 +252,31 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
         Returns:
 
         """
-        # Record that this entry hasn't been added
-        # to the index yet.
-        self._un_added_entries[entry.tid] = entry
-
         c = self.__control_component
 
         if c is None:
             c = self._pack_manager.get_input_source()
 
+        # Record that this entry hasn't been added
+        # to the index yet.
+        self._un_added_entries[entry.tid] = entry, c
+
         try:
             self.creation_records[c].add(entry.tid)
         except KeyError:
             self.creation_records[c] = {entry.tid}
+
+    def regret_record(self, entry: EntryType):
+        """
+
+        Args:
+            entry:
+
+        Returns:
+
+        """
+        entry, c = self._un_added_entries.pop(entry.tid)
+        self.creation_records[c].remove(entry.tid)
 
     def add_field_record(self, entry_id: int, field_name: str):
         """

--- a/forte/data/batchers.py
+++ b/forte/data/batchers.py
@@ -157,6 +157,7 @@ class FixedSizeDataPackBatcher(ProcessingBatcher[DataPack]):
         """
         instances: List[Dict] = []
         current_size = sum(self.current_batch_sources)
+
         for data in data_pack.get_data(context_type, requests, offset):
             instances.append(data)
             if len(instances) == self.batch_size - current_size:

--- a/forte/data/caster.py
+++ b/forte/data/caster.py
@@ -49,7 +49,7 @@ class MultiPackBoxer(Caster[DataPack, MultiPack]):
 
         """
         p = MultiPack()
-        p.add_pack(self.configs.pack_name)
+        p.add_pack_(pack, self.configs.pack_name)
         return p
 
     @classmethod

--- a/forte/data/caster.py
+++ b/forte/data/caster.py
@@ -49,7 +49,7 @@ class MultiPackBoxer(Caster[DataPack, MultiPack]):
 
         """
         p = MultiPack()
-        p.add_pack(pack, self.configs.pack_name)
+        p.add_pack(self.configs.pack_name)
         return p
 
     @classmethod

--- a/forte/data/container.py
+++ b/forte/data/container.py
@@ -80,7 +80,7 @@ class EntryContainer(Generic[E, L, G]):
         self._id_manager = EntryIdManager(state['serialization']['next_id'])
 
     @abstractmethod
-    def add_entry_creation_record(self, entry_id: int):
+    def record_new_entry(self, entry: E):
         raise NotImplementedError
 
     @abstractmethod

--- a/forte/data/container.py
+++ b/forte/data/container.py
@@ -84,6 +84,10 @@ class EntryContainer(Generic[E, L, G]):
         raise NotImplementedError
 
     @abstractmethod
+    def regret_record(self, entry: E):
+        raise NotImplementedError
+
+    @abstractmethod
     def add_field_record(self, entry_id: int, field_name: str):
         raise NotImplementedError
 

--- a/forte/data/data_pack.py
+++ b/forte/data/data_pack.py
@@ -19,7 +19,7 @@ from typing import (Dict, Iterable, Iterator, List, Optional, Type, Union, Any,
 import numpy as np
 from sortedcontainers import SortedList
 
-from forte.common.exception import EntryNotFoundError
+from forte.common.exception import EntryNotFoundError, ProcessExecutionException
 from forte.data import data_utils_io
 from forte.data.base_pack import BaseMeta, BasePack
 from forte.data.index import BaseIndex
@@ -67,7 +67,7 @@ class DataPack(BasePack[Entry, Link, Group]):
     """
 
     def __init__(self, doc_id: Optional[str] = None):
-        super().__init__()
+        super().__init__(doc_id)
         self._text = ""
 
         self.annotations: SortedList[Annotation] = SortedList()
@@ -150,13 +150,15 @@ class DataPack(BasePack[Entry, Link, Group]):
         """
         return self._text[span.begin: span.end]
 
+    # TODO: having to set the replace_func here is not very intuitive.
     def set_text(
             self, text: str, replace_func:
             Optional[Callable[[str], ReplaceOperationsType]] = None):
 
         if len(self._text) > 0:
-            logger.warning("The new text is overwriting the original one, "
-                           "which might cause unexpected behavior.")
+            raise ProcessExecutionException(
+                "The new text is overwriting the original one, "
+                "which might cause unexpected behavior.")
 
         span_ops = [] if replace_func is None else replace_func(text)
 
@@ -296,6 +298,7 @@ class DataPack(BasePack[Entry, Link, Group]):
 
         return Span(orig_begin, orig_end)
 
+    # TODO: Consider run add_entry automatically at some point.
     def add_entry(self, entry: EntryType) -> EntryType:
         r"""Force add an :class:`~forte.data.ontology.top.Entry` object to the
         :class:`DataPack` object. Allow duplicate entries in a pack.

--- a/forte/data/data_pack.py
+++ b/forte/data/data_pack.py
@@ -369,7 +369,9 @@ class DataPack(BasePack[Entry, Link, Group]):
                 else:
                     raise ValueError(
                         f"The end {end} of span is greater than the text "
-                        f"length {len(self.text)}, which is invalid."
+                        f"length {len(self.text)}, which is invalid. The "
+                        f"problematic entry is of type {entry.__class__} "
+                        f"at [{begin}:{end}]"
                     )
 
         elif isinstance(entry, Link):
@@ -402,7 +404,7 @@ class DataPack(BasePack[Entry, Link, Group]):
                 self.index.update_group_index([entry])
             self.index.deactivate_coverage_index()
 
-            self._un_added_entries.pop(entry.tid)
+            self._pending_entries.pop(entry.tid)
 
             return entry
         else:

--- a/forte/data/data_pack.py
+++ b/forte/data/data_pack.py
@@ -315,26 +315,26 @@ class DataPack(BasePack[Entry, Link, Group]):
         """
         return self.__add_entry_with_check(entry, True)
 
-    def add_or_get_entry(self, entry: EntryType) -> EntryType:
-        r"""Try to add an :class:`~forte.data.ontology.top.Entry` object to the
-        :class:`DataPack` object.
-
-        If the same entry already exists, will return the existing entry
-        instead of adding the new one. Note that we regard two entries as the
-        same if their :meth:`~forte.data.ontology.top.Entry.eq` have
-        the same return value, and users could
-        override :meth:`~forte.data.ontology.top.Entry.eq` in their
-        custom entry classes.
-
-        Args:
-            entry (Entry): An :class:`~forte.data.ontology.top.Entry`
-                object to be added to the pack.
-
-        Returns:
-            If a same entry already exists, returns the existing
-            entry. Otherwise, return the (input) entry just added.
-        """
-        return self.__add_entry_with_check(entry, False)
+# def add_or_get_entry(self, entry: EntryType) -> EntryType:
+#     r"""Try to add an :class:`~forte.data.ontology.top.Entry` object to the
+#     :class:`DataPack` object.
+#
+#     If the same entry already exists, will return the existing entry
+#     instead of adding the new one. Note that we regard two entries as the
+#     same if their :meth:`~forte.data.ontology.top.Entry.eq` have
+#     the same return value, and users could
+#     override :meth:`~forte.data.ontology.top.Entry.eq` in their
+#     custom entry classes.
+#
+#     Args:
+#         entry (Entry): An :class:`~forte.data.ontology.top.Entry`
+#             object to be added to the pack.
+#
+#     Returns:
+#         If a same entry already exists, returns the existing
+#         entry. Otherwise, return the (input) entry just added.
+#     """
+#     return self.__add_entry_with_check(entry, False)
 
     def __add_entry_with_check(self, entry: EntryType,
                                allow_duplicate: bool = True) -> EntryType:

--- a/forte/data/datasets/wikipedia/dbpedia_based_reader.py
+++ b/forte/data/datasets/wikipedia/dbpedia_based_reader.py
@@ -48,14 +48,11 @@ def add_struct(pack: DataPack, struct_statements: List):
             struct_ = get_resource_fragment(struct_type)
 
             if struct_ == 'Section':
-                section = WikiSection(pack, begin, end)
-                pack.add_entry(section)
+                WikiSection(pack, begin, end)
             elif struct_ == 'Paragraph':
-                para = WikiParagraph(pack, begin, end)
-                pack.add_entry(para)
+                WikiParagraph(pack, begin, end)
             elif struct_ == 'Title':
-                title = WikiTitle(pack, begin, end)
-                pack.add_entry(title)
+                WikiTitle(pack, begin, end)
             else:
                 logging.warning("Unknown struct type: %s", struct_type)
 
@@ -82,7 +79,6 @@ def add_anchor_links(pack: DataPack, text_link_statements: List[state_type],
                 if target_page_name in redirects:
                     target_page_name = redirects[target_page_name]
                 anchor.target_page_name = target_page_name
-        pack.add_entry(anchor)
 
 
 def add_info_boxes(pack: DataPack, info_box_statements: List):
@@ -92,7 +88,6 @@ def add_info_boxes(pack: DataPack, info_box_statements: List):
         info_box = WikiInfoBoxMapped(pack)
         info_box.key = slot_name
         info_box.value = slot_value
-        pack.add_entry(info_box)
 
 
 class DBpediaWikiReader(PackReader):
@@ -150,7 +145,6 @@ class DBpediaWikiReader(PackReader):
 
         pack.set_text(full_text)
         page = WikiPage(pack, 0, len(full_text))
-        pack.add_entry(page)
         page.page_id = str_data['oldid']
         page.page_name = doc_name
 

--- a/forte/data/datasets/wikipedia/dbpedia_infobox_reader.py
+++ b/forte/data/datasets/wikipedia/dbpedia_infobox_reader.py
@@ -46,7 +46,6 @@ def add_property(pack: DataPack, statements: List):
         info_box = WikiInfoBoxProperty(pack)
         info_box.key = slot_name
         info_box.value = slot_value
-        pack.add_entry(info_box)
 
 
 def add_info_boxes(pack: DataPack, info_box_statements: List):
@@ -54,7 +53,6 @@ def add_info_boxes(pack: DataPack, info_box_statements: List):
         info_box = WikiInfoBoxMapped(pack)
         info_box.key = v.toPython()
         info_box.value = get_resource_name(o)
-        pack.add_entry(info_box)
 
 
 def read_index(pack_index_path: str) -> Dict[str, str]:

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -440,22 +440,6 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         else:
             return target[target.index(entry)]  # type: ignore
 
-    def add_or_get_entry(self, entry: EntryType) -> EntryType:
-        r"""Try to add an :class:`Entry` object to the :class:`Multipack`
-        object. If a same entry already exists, will return the existing entry
-        instead of adding the new one. Note that we regard two entries to be
-        same if their :meth:`eq` have the same return value, and users could
-        override :meth:`eq` in their custom entry classes.
-
-        Args:
-            entry (Entry): An :class:`Entry` object to be added to the datapack.
-
-        Returns:
-            If a same entry already exists, returns the existing
-            entry. Otherwise, return the (input) entry just added.
-        """
-        return self.__add_entry_with_check(entry, False)
-
     def add_entry(self, entry: EntryType) -> EntryType:
         r"""Force add an :class:`Entry` object to the :class:`MultiPack` object.
 

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -135,6 +135,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         """ A destructor for the MultiPack. During destruction, the Multi Pack
         will inform the PackManager that it won't need the DataPack anymore.
         """
+        super().__del__()
         for pack_id in self._pack_ref:
             self._pack_manager.dereference_pack(pack_id)
 
@@ -172,7 +173,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             )
 
         pack: DataPack = DataPack()
-        self.add_pack_(pack)
+        self.add_pack_(pack, pack_name)
         return pack
 
     def add_pack_(self, pack: DataPack, pack_name: Optional[str] = None):
@@ -422,6 +423,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
                     entry, MultiPackGroup):
                 self.index.update_group_index([entry])
 
+            self._un_added_entries.pop(entry.tid)
             return entry
         else:
             return target[target.index(entry)]  # type: ignore

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -149,7 +149,43 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             "MultiPack objects do not contain text, please refer to a "
             "specific data pack to get text.")
 
-    def add_pack(self, pack: DataPack, pack_name: Optional[str] = None):
+    def add_pack(self, pack_name: Optional[str] = None) -> DataPack:
+        """
+        Create a data pack and add it to this multi pack. If pack_name is not
+        None, it will be used to index the data pack. Otherwise, a default name
+        based on the pack id will be created for this data pack. The created
+        data pack will be returned.
+
+        Args:
+            pack_name (str): The pack name used for the new created pack
+
+        Returns: The newly created data pack.
+
+        """
+        if pack_name in self._name_index:
+            raise ValueError(
+                f"The name {pack_name} has already been taken.")
+        if pack_name is not None and not isinstance(pack_name, str):
+            raise ValueError(
+                f"key of the pack should be str, but got "
+                f"" f"{type(pack_name)}"
+            )
+
+        pack: DataPack = DataPack()
+        self.add_pack_(pack)
+        return pack
+
+    def add_pack_(self, pack: DataPack, pack_name: Optional[str] = None):
+        """
+        Add a existing data pack to the multi pack.
+
+        Args:
+            pack (DataPack): The existing data pack.
+            pack_name (str): The name to used in this multi pack.
+
+        Returns:
+
+        """
         if pack_name in self._name_index:
             raise ValueError(
                 f"The name {pack_name} has already been taken.")
@@ -236,7 +272,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
     def update_pack(self, named_packs: Dict[str, DataPack]):
         for pack_name, pack in named_packs.items():
-            self.add_pack(pack, pack_name)
+            self.add_pack_(pack, pack_name)
 
     def iter_packs(self) -> Iterator[Tuple[str, DataPack]]:
         for pack_name, pack in zip(self._pack_names, self.packs):

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -300,6 +300,18 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
     def iter_groups(self):
         yield from self.groups
 
+    def add_all_remaining_entries(self):
+        """
+        Calling this function will add the entries that are not added to the
+        pack manually.
+
+        Returns:
+
+        """
+        super().add_all_remaining_entries()
+        for pack in self.packs:
+            pack.add_all_remaining_entries()
+
     def get_single_pack_data(
             self,
             pack_index: int,
@@ -423,7 +435,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
                     entry, MultiPackGroup):
                 self.index.update_group_index([entry])
 
-            self._un_added_entries.pop(entry.tid)
+            self._pending_entries.pop(entry.tid)
             return entry
         else:
             return target[target.index(entry)]  # type: ignore

--- a/forte/data/ontology/code_generation_objects.py
+++ b/forte/data/ontology/code_generation_objects.py
@@ -38,28 +38,33 @@ class ImportManager:
         self.__root = root
         self.__module_name = module_name
         self.__import_statements: List[str] = []
+        # Defining names imported by this module.
         self.__imported_names: Dict[str, str] = {}
+        # Defining names to be added by this generation module
+        self.__defining_names: Dict[str, str] = {}
         self.__short_name_pool: Set[str] = set()
         self.__fix_modules = False
 
     def fix_modules(self):
         self.__fix_modules = True
 
-    def is_known_name(self, class_name):
+    def is_known_name(self, full_class_name):
         """
         Check whether the class name can be used. It will check the class name
         in both the top manager or the current manager.
 
         Args:
-            class_name: The name to be check.
+            full_class_name: The name to be check.
 
         Returns: True if the class_name can be used, which means it is either
             imported or it is of a primitive type.
 
         """
-        return (class_name in NON_COMPOSITES or
-                class_name in COMPOSITES or
-                self.is_imported(class_name))
+        return (full_class_name in NON_COMPOSITES or
+                full_class_name in COMPOSITES or
+                self.is_imported(full_class_name) or
+                full_class_name in self.__defining_names
+                )
 
     def is_imported(self, class_name):
         """
@@ -85,6 +90,9 @@ class ImportManager:
     def get_name_to_use(self, full_name):
         if full_name in SUPPORTED_PRIMITIVES:
             return full_name
+
+        if full_name in self.__defining_names:
+            return self.__defining_names[full_name]
 
         if self.is_imported(full_name):
             return self.__imported_names[full_name]
@@ -136,6 +144,22 @@ class ImportManager:
             as_name = self.__find_next_available(class_name)
             self.__short_name_pool.add(as_name)
             return as_name
+
+    def add_defining_objects(self, full_name: str):
+        if self.__fix_modules:
+            # After fixing the modules, we should not add objects for import.
+            raise CodeGenerationException(
+                f'The module [{self.__module_name}] is fixed, cannot add '
+                f'more objects.')
+
+        if full_name not in self.__defining_names:
+            class_name = full_name.split('.')[-1]
+            if class_name not in self.__short_name_pool:
+                self.__short_name_pool.add(class_name)
+            else:
+                logging.warning(f"Re-declared a new class named [{class_name}]"
+                                f", which is probably used in import.")
+            self.__defining_names[full_name] = class_name
 
     def add_object_to_import(self, full_name: str):
         if self.__fix_modules:
@@ -447,7 +471,7 @@ class DictProperty(Property):
                 (f"{name} = {{}} if {name} is None else {name}", 1),
                 (f"self.set_fields("
                  f"{self.field_name}="
-                 f"dict([(k, self.pack.add_entry_(v)) "
+                 f"dict([(k, v.tid) "
                  f"for k, v in {name}.items()]))", 1),
                 ('', 0),
             ])
@@ -490,7 +514,7 @@ class DictProperty(Property):
                 ('', 0),
                 (f"def add_{name}(self, key: {key_type}, value: {value_type}):",
                  0),
-                (f"self.{self.field_name}[key] = self.pack.add_entry_(value)",
+                (f"self.{self.field_name}[key] = value.tid",
                  1),
             ])
         else:
@@ -559,7 +583,7 @@ class ListProperty(Property):
                 (f"{name} = [] if {name} is None else {name}", 1),
                 (f"self.set_fields("
                  f"{self.field_name}="
-                 f"[self.pack.add_entry_(obj) for obj in {name}])", 1),
+                 f"[obj.tid for obj in {name}])", 1),
                 ('', 0),
             ])
         else:
@@ -604,7 +628,7 @@ class ListProperty(Property):
                 ('', 0),
                 (f"def add_{name}(self, a_{name}: {item_type}):", 0),
                 (f"self.{self.field_name}.append("
-                 f"self.pack.add_entry_(a_{name}))", 1),
+                 f"a_{name}.tid)", 1),
             ])
         else:
             lines.extend([

--- a/forte/data/ontology/code_generation_objects.py
+++ b/forte/data/ontology/code_generation_objects.py
@@ -157,8 +157,9 @@ class ImportManager:
             if class_name not in self.__short_name_pool:
                 self.__short_name_pool.add(class_name)
             else:
-                logging.warning(f"Re-declared a new class named [{class_name}]"
-                                f", which is probably used in import.")
+                logging.warning(
+                    "Re-declared a new class named [%s]"
+                    ", which is probably used in import.", class_name)
             self.__defining_names[full_name] = class_name
 
     def add_object_to_import(self, full_name: str):

--- a/forte/data/ontology/core.py
+++ b/forte/data/ontology/core.py
@@ -77,7 +77,7 @@ class Entry(Generic[ContainerType]):
         self.record_creation()
 
     def record_creation(self):
-        self.__pack.add_entry_creation_record(self._tid)
+        self.__pack.record_new_entry(self)
 
     def reset(self):
         """

--- a/forte/data/ontology/core.py
+++ b/forte/data/ontology/core.py
@@ -72,12 +72,15 @@ class Entry(Generic[ContainerType]):
         # to be checked by the pack.
         self.__pack: ContainerType = pack
         self.__field_modified: Set[str] = set()
-        pack.validate(self)
 
+        pack.validate(self)
         self.record_creation()
 
     def record_creation(self):
         self.__pack.record_new_entry(self)
+
+    def regret_creation(self):
+        self.__pack.regret_record(self)
 
     def reset(self):
         """
@@ -86,7 +89,6 @@ class Entry(Generic[ContainerType]):
         Returns:
 
         """
-        # TODO: do we need to record this reset action as an edit?
         self.__init__(self.__pack)
 
     def __getstate__(self):

--- a/forte/data/ontology/ontology_code_generator.py
+++ b/forte/data/ontology/ontology_code_generator.py
@@ -573,6 +573,10 @@ class OntologyCodeGenerator:
             en = EntryName(raw_entry_name)
             entry_item, properties = self.parse_entry(en, definition)
 
+            # Add it as a defining object.
+            self.import_managers.get(en.module_name).add_defining_objects(
+                raw_entry_name)
+
             # Get or set module writer only if the ontology to be generated
             # is not already installed.
             if not is_installed:

--- a/forte/data/ontology/top.py
+++ b/forte/data/ontology/top.py
@@ -363,25 +363,30 @@ class Query(Generics):
 
     def __init__(self, pack: PackType):
         super().__init__(pack)
-        self.value: QueryType = None
-        self.results: Dict[str, float] = {}
+        self._value: QueryType = None
+        self._results: Dict[str, float] = {}
 
-    def set_value(self, value: QueryType):
+    @property
+    def value(self) -> QueryType:
+        return self._value
+
+    @value.setter
+    def value(self, value: QueryType):
         r"""Sets the value of the query.
 
         Args:
             value (numpy array or str): A vector or a string (in case of
             traditional models) representing the query.
         """
-        self.value = value
+        self._value = value
 
     @property
     def results(self):
-        return self.results
+        return self._results
 
     @results.setter
     def results(self, pid_to_score: Dict[str, float]):
-        self.results = pid_to_score
+        self._results = pid_to_score
 
     def add_result(self, pid: str, score: float):
         """

--- a/forte/data/ontology/top.py
+++ b/forte/data/ontology/top.py
@@ -390,7 +390,7 @@ class Query(Generics):
 
     def add_result(self, pid: str, score: float):
         """
-        Set the result score for a particular pid.
+        Set the result score for a particular pack (based on the pack id).
 
         Args:
             pid: the pack id.

--- a/forte/data/ontology/top.py
+++ b/forte/data/ontology/top.py
@@ -87,20 +87,6 @@ class Annotation(Entry):
         if begin < 0:
             raise ValueError('The begin cannot be negative.')
 
-        if end > len(pack_text):
-            if len(pack_text) == 0:
-                raise ValueError(
-                    f"The end {end} of span is greater than the text length "
-                    f"{len(pack_text)}, which is invalid. The text length is 0,"
-                    f" so it may be the case the you haven't set text for the"
-                    f" data pack."
-                )
-            else:
-                raise ValueError(
-                    f"The end {end} of span is greater than the text length "
-                    f"{len(pack_text)}, which is invalid."
-                )
-
         self._span = Span(begin, end)
 
     def __hash__(self):

--- a/forte/data/ontology/top.py
+++ b/forte/data/ontology/top.py
@@ -58,7 +58,7 @@ class Annotation(Entry):
 
     def __init__(self, pack: PackType, begin: int, end: int):
         super().__init__(pack)
-        self.set_span(pack.text, begin, end)  # type: ignore
+        self.set_span(begin, end)
 
     @property
     def span(self):
@@ -72,7 +72,7 @@ class Annotation(Entry):
     def end(self):
         return self._span.end
 
-    def set_span(self, pack_text: str, begin: int, end: int):
+    def set_span(self, begin: int, end: int):
         r"""Set the span of the annotation.
         """
         if not isinstance(begin, int) or not isinstance(end, int):

--- a/forte/data/ontology/top.py
+++ b/forte/data/ontology/top.py
@@ -58,7 +58,7 @@ class Annotation(Entry):
 
     def __init__(self, pack: PackType, begin: int, end: int):
         super().__init__(pack)
-        self.set_span(begin, end)
+        self.set_span(pack.text, begin, end)  # type: ignore
 
     @property
     def span(self):
@@ -72,7 +72,7 @@ class Annotation(Entry):
     def end(self):
         return self._span.end
 
-    def set_span(self, begin: int, end: int):
+    def set_span(self, pack_text: str, begin: int, end: int):
         r"""Set the span of the annotation.
         """
         if not isinstance(begin, int) or not isinstance(end, int):
@@ -83,6 +83,24 @@ class Annotation(Entry):
         if begin > end:
             raise ValueError(
                 f"The begin {begin} of span is greater than the end {end}")
+
+        if begin < 0:
+            raise ValueError('The begin cannot be negative.')
+
+        if end > len(pack_text):
+            if len(pack_text) == 0:
+                raise ValueError(
+                    f"The end {end} of span is greater than the text length "
+                    f"{len(pack_text)}, which is invalid. The text length is 0,"
+                    f" so it may be the case the you haven't set text for the"
+                    f" data pack."
+                )
+            else:
+                raise ValueError(
+                    f"The end {end} of span is greater than the text length "
+                    f"{len(pack_text)}, which is invalid."
+                )
+
         self._span = Span(begin, end)
 
     def __hash__(self):
@@ -370,6 +388,27 @@ class Query(Generics):
             traditional models) representing the query.
         """
         self.value = value
+
+    @property
+    def results(self):
+        return self.results
+
+    @results.setter
+    def results(self, pid_to_score: Dict[str, float]):
+        self.results = pid_to_score
+
+    def add_result(self, pid: str, score: float):
+        """
+        Set the result score for a particular pid.
+
+        Args:
+            pid: the pack id.
+            score: the score for the pack
+
+        Returns:
+
+        """
+        self.results[pid] = score
 
     def update_results(self, pid_to_score: Dict[str, float]):
         r"""Updates the results for this query.

--- a/forte/data/readers/base_reader.py
+++ b/forte/data/readers/base_reader.py
@@ -185,7 +185,6 @@ class BaseReader(PipelineComponent[PackType], ABC):
             if self.from_cache:
                 for pack in self.read_from_cache(
                         self._get_cache_location(collection)):
-                    print('call from reader')
                     pack.add_all_remaining_entries()
                     yield pack
             else:

--- a/forte/data/readers/base_reader.py
+++ b/forte/data/readers/base_reader.py
@@ -120,11 +120,11 @@ class BaseReader(PipelineComponent[PackType], ABC):
                 "Got None collection, cannot parse as data pack.")
 
         for p in self._parse_pack(collection):
-            for entry in p:
-                # Here the creation will be recorded to the reader because
-                # we have set the reader to be the initial_reader in the
-                # pack manager.
-                entry.record_creation()
+            # for entry in p:
+            #     # Here the creation will be recorded to the reader because
+            #     # we have set the reader to be the initial_reader in the
+            #     # pack manager.
+            #     entry.record_creation()
             yield p
 
     @abstractmethod
@@ -185,6 +185,7 @@ class BaseReader(PipelineComponent[PackType], ABC):
             if self.from_cache:
                 for pack in self.read_from_cache(
                         self._get_cache_location(collection)):
+                    pack.add_all_remaining_entry()
                     yield pack
             else:
                 not_first = False
@@ -199,6 +200,7 @@ class BaseReader(PipelineComponent[PackType], ABC):
                             f"collection {collection}, returned {type(pack)}."
                         )
                     not_first = True
+                    pack.add_all_remaining_entry()
                     yield pack
 
     def iter(self, *args, **kwargs) -> Iterator[PackType]:

--- a/forte/data/readers/base_reader.py
+++ b/forte/data/readers/base_reader.py
@@ -185,7 +185,8 @@ class BaseReader(PipelineComponent[PackType], ABC):
             if self.from_cache:
                 for pack in self.read_from_cache(
                         self._get_cache_location(collection)):
-                    pack.add_all_remaining_entry()
+                    print('call from reader')
+                    pack.add_all_remaining_entries()
                     yield pack
             else:
                 not_first = False
@@ -199,8 +200,9 @@ class BaseReader(PipelineComponent[PackType], ABC):
                             f"No Pack object read from the given "
                             f"collection {collection}, returned {type(pack)}."
                         )
+
                     not_first = True
-                    pack.add_all_remaining_entry()
+                    pack.add_all_remaining_entries()
                     yield pack
 
     def iter(self, *args, **kwargs) -> Iterator[PackType]:

--- a/forte/data/readers/conll03_reader.py
+++ b/forte/data/readers/conll03_reader.py
@@ -78,8 +78,6 @@ class CoNLL03Reader(PackReader):
                 token.chunk = chunk_id
                 token.ner = ner_tag
 
-                pack.add_entry(token)
-
                 text += word + " "
                 offset = word_end + 1
                 has_rows = True
@@ -88,8 +86,7 @@ class CoNLL03Reader(PackReader):
                     # Skip consecutive empty lines.
                     continue
                 # add sentence
-                sent = Sentence(pack, sentence_begin, offset - 1)
-                pack.add_entry(sent)
+                Sentence(pack, sentence_begin, offset - 1)
 
                 sentence_begin = offset
                 sentence_cnt += 1
@@ -97,16 +94,12 @@ class CoNLL03Reader(PackReader):
 
         if has_rows:
             # Add the last sentence if exists.
-            sent = Sentence(pack, sentence_begin, offset - 1)
+            Sentence(pack, sentence_begin, offset - 1)
             sentence_cnt += 1
-            pack.add_entry(sent)
 
         pack.set_text(text, replace_func=self.text_replace_operation)
 
-        pack.set_text(text, replace_func=self.text_replace_operation)
-
-        document = Document(pack, 0, len(text))
-        pack.add_entry(document)
+        Document(pack, 0, len(text))
 
         pack.meta.doc_id = file_path
         doc.close()

--- a/forte/data/readers/conll03_reader.py
+++ b/forte/data/readers/conll03_reader.py
@@ -78,7 +78,7 @@ class CoNLL03Reader(PackReader):
                 token.chunk = chunk_id
                 token.ner = ner_tag
 
-                pack.add_or_get_entry(token)
+                pack.add_entry(token)
 
                 text += word + " "
                 offset = word_end + 1
@@ -89,7 +89,7 @@ class CoNLL03Reader(PackReader):
                     continue
                 # add sentence
                 sent = Sentence(pack, sentence_begin, offset - 1)
-                pack.add_or_get_entry(sent)
+                pack.add_entry(sent)
 
                 sentence_begin = offset
                 sentence_cnt += 1
@@ -99,12 +99,12 @@ class CoNLL03Reader(PackReader):
             # Add the last sentence if exists.
             sent = Sentence(pack, sentence_begin, offset - 1)
             sentence_cnt += 1
-            pack.add_or_get_entry(sent)
+            pack.add_entry(sent)
 
         pack.set_text(text, replace_func=self.text_replace_operation)
 
         document = Document(pack, 0, len(text))
-        pack.add_or_get_entry(document)
+        pack.add_entry(document)
 
         pack.meta.doc_id = file_path
         doc.close()

--- a/forte/data/readers/conll03_reader.py
+++ b/forte/data/readers/conll03_reader.py
@@ -101,10 +101,11 @@ class CoNLL03Reader(PackReader):
             sentence_cnt += 1
             pack.add_or_get_entry(sent)
 
+        pack.set_text(text, replace_func=self.text_replace_operation)
+
         document = Document(pack, 0, len(text))
         pack.add_or_get_entry(document)
 
-        pack.set_text(text, replace_func=self.text_replace_operation)
         pack.meta.doc_id = file_path
         doc.close()
 

--- a/forte/data/readers/conllu_ud_reader.py
+++ b/forte/data/readers/conllu_ud_reader.py
@@ -168,7 +168,8 @@ class ConllUDReader(PackReader):
                 doc_sent_begin = doc_offset
                 doc_num_sent += 1
 
-        data_pack.set_text(doc_text.strip())
+        doc_text = doc_text.strip()
+        data_pack.set_text(doc_text)
 
         # add doc to data_pack
         Document(data_pack, 0, len(doc_text))

--- a/forte/data/readers/conllu_ud_reader.py
+++ b/forte/data/readers/conllu_ud_reader.py
@@ -128,8 +128,6 @@ class ConllUDReader(PackReader):
                 token.ud_features = token_comps['ud_features']
                 token.ud_misc = token_comps['ud_misc']
 
-                data_pack.add_or_get_entry(token)
-
                 sent_tokens[str(token_comps["id"])] = (token_comps, token)
 
                 sent_text += word + " "
@@ -154,7 +152,6 @@ class ConllUDReader(PackReader):
                         head = sent_tokens[token_comps["head"]][1]
                         dependency = Dependency(data_pack, head, token)
                         dependency.dep_label = label
-                        data_pack.add_or_get_entry(dependency)
 
                     # add enhanced dependencies
                     for dep in token_comps["enhanced_dependency_relations"]:
@@ -164,11 +161,9 @@ class ConllUDReader(PackReader):
                             enhanced_dependency = \
                                 EnhancedDependency(data_pack, head, token)
                             enhanced_dependency.dep_label = label
-                            data_pack.add_or_get_entry(enhanced_dependency)
 
                 # add sentence
-                sent = Sentence(data_pack, doc_sent_begin, doc_offset - 1)
-                data_pack.add_or_get_entry(sent)
+                Sentence(data_pack, doc_sent_begin, doc_offset - 1)
 
                 doc_sent_begin = doc_offset
                 doc_num_sent += 1
@@ -176,8 +171,7 @@ class ConllUDReader(PackReader):
         data_pack.set_text(doc_text.strip())
 
         # add doc to data_pack
-        document = Document(data_pack, 0, len(doc_text))
-        data_pack.add_or_get_entry(document)
+        Document(data_pack, 0, len(doc_text))
         data_pack.meta.doc_id = doc_id
 
         yield data_pack

--- a/forte/data/readers/conllu_ud_reader.py
+++ b/forte/data/readers/conllu_ud_reader.py
@@ -173,10 +173,11 @@ class ConllUDReader(PackReader):
                 doc_sent_begin = doc_offset
                 doc_num_sent += 1
 
+        data_pack.set_text(doc_text.strip())
+
         # add doc to data_pack
         document = Document(data_pack, 0, len(doc_text))
         data_pack.add_or_get_entry(document)
         data_pack.meta.doc_id = doc_id
-        data_pack.set_text(doc_text.strip())
 
         yield data_pack

--- a/forte/data/readers/html_reader.py
+++ b/forte/data/readers/html_reader.py
@@ -287,8 +287,10 @@ class HTMLReader(PackReader):
         else:
             text = data_source
 
-        Document(pack, 0, len(text))
         self.set_text(pack, text)
+        # Note that pack.text can be different from the text passed in, due to
+        # the text_replace_operation
+        Document(pack, 0, len(pack.text))
 
         yield pack
 

--- a/forte/data/readers/html_reader.py
+++ b/forte/data/readers/html_reader.py
@@ -68,7 +68,6 @@ endendtag = re.compile('>')
 # </ and the tag name, so maybe this should be fixed
 endtagfind = re.compile(r'</\s*([a-zA-Z][-.a-zA-Z0-9:_]*)\s*>')
 
-
 __all__ = [
     "HTMLReader",
 ]
@@ -77,6 +76,7 @@ __all__ = [
 class ForteHTMLParser(HTMLParser):
     r"""Parser that stores spans that HTMLReader can use.
     """
+
     def __init__(self):
         super().__init__()
         self.spans = []
@@ -220,6 +220,7 @@ class HTMLReader(PackReader):
     It takes in list of html strings, cleans the HTML tags and stores the
     cleaned text in pack.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.init_with_fileloc = False
@@ -244,6 +245,7 @@ class HTMLReader(PackReader):
             elif os.path.isfile(content):
                 def data_yielder(data):
                     yield data
+
                 self.init_with_fileloc = True
                 return data_yielder(content)
             else:  # Treat it as a string
@@ -255,6 +257,7 @@ class HTMLReader(PackReader):
             def data_iterator(data):
                 for html_string in data:
                     yield html_string
+
             return data_iterator(content)
 
         else:
@@ -284,8 +287,7 @@ class HTMLReader(PackReader):
         else:
             text = data_source
 
-        document = Document(pack, 0, len(text))
-        pack.add_or_get_entry(document)
+        Document(pack, 0, len(text))
         self.set_text(pack, text)
 
         yield pack

--- a/forte/data/readers/ms_marco_passage_reader.py
+++ b/forte/data/readers/ms_marco_passage_reader.py
@@ -74,9 +74,9 @@ class MSMarcoPassageReader(PackReader):
         doc_id, doc_text = doc_info
         data_pack.meta.doc_id = doc_id
 
-        # add documents
-        data_pack.add_or_get_entry(Document(data_pack, 0, len(doc_text)))
         data_pack.set_text(doc_text)
+        # add documents
+        data_pack.add_entry(Document(data_pack, 0, len(doc_text)))
 
         yield data_pack
 

--- a/forte/data/readers/ms_marco_passage_reader.py
+++ b/forte/data/readers/ms_marco_passage_reader.py
@@ -76,7 +76,7 @@ class MSMarcoPassageReader(PackReader):
 
         data_pack.set_text(doc_text)
         # add documents
-        data_pack.add_entry(Document(data_pack, 0, len(doc_text)))
+        Document(data_pack, 0, len(doc_text))
 
         yield data_pack
 

--- a/forte/data/readers/multipack_sentence_reader.py
+++ b/forte/data/readers/multipack_sentence_reader.py
@@ -81,8 +81,7 @@ class MultiPackSentenceReader(MultiPackReader):
                     continue
 
                 # add sentence
-                sent = Sentence(input_pack, offset, offset + len(line))
-                input_pack.add_entry(sent)
+                Sentence(input_pack, offset, offset + len(line))
                 text += line + '\n'
                 offset = offset + len(line) + 1
 

--- a/forte/data/readers/multipack_sentence_reader.py
+++ b/forte/data/readers/multipack_sentence_reader.py
@@ -20,10 +20,8 @@ from typing import Any, Iterator, Dict, Tuple
 from forte.common.configuration import Config
 from forte.common.resources import Resources
 from forte.data.data_utils_io import dataset_path_iterator_with_base
-from forte.data.data_pack import DataPack
 from forte.data.multi_pack import MultiPack
 from forte.data.readers.base_reader import MultiPackReader
-
 from ft.onto.base_ontology import Sentence
 
 __all__ = [
@@ -71,7 +69,10 @@ class MultiPackSentenceReader(MultiPackReader):
                      file_path.startswith(base_dir) and len(base_dir):]
             doc_id = doc_id.strip(os.path.sep)
 
-            input_pack = DataPack(doc_id=doc_id)
+            input_pack = m_pack.add_pack(input_pack_name)
+            input_pack.doc_id = doc_id
+            input_pack.set_text(
+                text, replace_func=self.text_replace_operation)
 
             for line in doc:
                 line = line.strip()
@@ -85,15 +86,8 @@ class MultiPackSentenceReader(MultiPackReader):
                 text += line + '\n'
                 offset = offset + len(line) + 1
 
-            input_pack.set_text(
-                text, replace_func=self.text_replace_operation)
-
-            output_pack = DataPack()
-
-            m_pack.update_pack({
-                input_pack_name: input_pack,
-                output_pack_name: output_pack
-            })
+            # Create a output pack without text.
+            m_pack.add_pack(output_pack_name)
 
             yield m_pack
 

--- a/forte/data/readers/multipack_sentence_reader.py
+++ b/forte/data/readers/multipack_sentence_reader.py
@@ -71,8 +71,6 @@ class MultiPackSentenceReader(MultiPackReader):
 
             input_pack = m_pack.add_pack(input_pack_name)
             input_pack.doc_id = doc_id
-            input_pack.set_text(
-                text, replace_func=self.text_replace_operation)
 
             for line in doc:
                 line = line.strip()
@@ -85,9 +83,10 @@ class MultiPackSentenceReader(MultiPackReader):
                 text += line + '\n'
                 offset = offset + len(line) + 1
 
+            input_pack.set_text(
+                text, replace_func=self.text_replace_operation)
             # Create a output pack without text.
             m_pack.add_pack(output_pack_name)
-
             yield m_pack
 
     @classmethod

--- a/forte/data/readers/multipack_terminal_reader.py
+++ b/forte/data/readers/multipack_terminal_reader.py
@@ -82,8 +82,7 @@ class MultiPackTerminalReader(MultiPackReader):
         pack = multi_pack.add_pack(self.config.pack_name)
         pack.set_text(data_source, replace_func=self.text_replace_operation)
 
-        utterance = Utterance(pack, 0, len(data_source))
-        pack.add_entry(utterance)
+        Utterance(pack, 0, len(data_source))
 
         yield multi_pack
 

--- a/forte/data/readers/multipack_terminal_reader.py
+++ b/forte/data/readers/multipack_terminal_reader.py
@@ -20,7 +20,6 @@ from typing import Iterator, Dict, Any
 
 from forte.common.configuration import Config
 from forte.common.resources import Resources
-from forte.data.data_pack import DataPack
 from forte.data.multi_pack import MultiPack
 from forte.data.readers.base_reader import MultiPackReader
 from ft.onto.base_ontology import Utterance
@@ -73,19 +72,18 @@ class MultiPackTerminalReader(MultiPackReader):
 
         # use context to build the query
         if self.resource.get("user_utterance"):
-            user_pack = self.resource.get("user_utterance")[-1]
-            multi_pack.update_pack({"user_utterance": user_pack})
+            multi_pack.add_pack_(
+                self.resource.get("user_utterance")[-1], "user_utterance")
 
         if self.resource.get("bot_utterance"):
-            bot_pack = self.resource.get("bot_utterance")[-1]
-            multi_pack.update_pack({"bot_utterance": bot_pack})
+            multi_pack.add_pack_(
+                self.resource.get("bot_utterance")[-1], "bot_utterance")
 
-        pack = DataPack()
+        pack = multi_pack.add_pack(self.config.pack_name)
+        pack.set_text(data_source, replace_func=self.text_replace_operation)
+
         utterance = Utterance(pack, 0, len(data_source))
         pack.add_entry(utterance)
-
-        pack.set_text(data_source, replace_func=self.text_replace_operation)
-        multi_pack.update_pack({self.config.pack_name: pack})
 
         yield multi_pack
 

--- a/forte/data/readers/ontonotes_reader.py
+++ b/forte/data/readers/ontonotes_reader.py
@@ -275,13 +275,12 @@ class OntonotesReader(PackReader):
                 pack.add_entry(group)
 
             text = " ".join(words)
-            document = Document(pack, 0, len(text))
-            pack.add_entry(document)
-
-            if document_id is not None:
-                pack.set_meta(doc_id=document_id)
             pack.set_text(text, replace_func=self.text_replace_operation)
 
+            document = Document(pack, 0, len(text))
+            pack.add_entry(document)
+            if document_id is not None:
+                pack.doc_id = document_id
         yield pack
 
     def _process_entity_annotations(

--- a/forte/data/readers/ontonotes_reader.py
+++ b/forte/data/readers/ontonotes_reader.py
@@ -185,7 +185,6 @@ class OntonotesReader(PackReader):
                         token.pos = fields.pos_tag
                     if fields.word_sense is not None:
                         token.sense = fields.word_sense
-                    pack.add_entry(token)
 
                     # add entity mentions
                     current_entity_mention = self._process_entity_annotations(
@@ -206,7 +205,6 @@ class OntonotesReader(PackReader):
 
                         if fields.framenet_id is not None:
                             pred_mention.framenet_id = fields.framenet_id
-                        pack.add_entry(pred_mention)
 
                         if word_is_verbal_predicate:
                             verbal_predicates.append(pred_mention)
@@ -249,7 +247,6 @@ class OntonotesReader(PackReader):
                         for arg in pred_arg:
                             link = PredicateLink(pack, predicate, arg[0])
                             link.arg_type = arg[1]
-                            pack.add_entry(link)
 
                     verbal_predicates = []
                     current_pred_arg = []
@@ -262,7 +259,6 @@ class OntonotesReader(PackReader):
                         sent.speaker = speaker
                     if part_id is not None:
                         sent.part_id = int(part_id)
-                    pack.add_entry(sent)
 
                     sentence_begin = offset
 
@@ -272,13 +268,11 @@ class OntonotesReader(PackReader):
             for _, mention_list in groups.items():
                 group = CoreferenceGroup(pack)
                 group.add_members(mention_list)
-                pack.add_entry(group)
 
             text = " ".join(words)
             pack.set_text(text, replace_func=self.text_replace_operation)
 
-            document = Document(pack, 0, len(text))
-            pack.add_entry(document)
+            _ = Document(pack, 0, len(text))
             if document_id is not None:
                 pack.doc_id = document_id
         yield pack
@@ -306,7 +300,6 @@ class OntonotesReader(PackReader):
             # Exiting a span, add and then reset the current span.
             entity = EntityMention(pack, current_entity_mention[0], word_end)
             entity.ner_type = current_entity_mention[1]
-            pack.add_entry(entity)
 
             current_entity_mention = None
 
@@ -340,7 +333,6 @@ class OntonotesReader(PackReader):
 
                 if arg_type != "V":
                     pred_arg = PredicateArgument(pack, arg_begin, word_end)
-                    pred_arg = pack.add_entry(pred_arg)
 
                     verbal_pred_args[label_index].append((pred_arg, arg_type))
                 current_pred_arg[label_index] = None
@@ -365,8 +357,6 @@ class OntonotesReader(PackReader):
                     group_id = int(segment[1:-1])
 
                     coref_mention = EntityMention(pack, word_begin, word_end)
-                    coref_mention = pack.add_entry(coref_mention)
-
                     groups[group_id].append(coref_mention)
                 else:
                     # The span is starting, so we record the index of the word.
@@ -377,6 +367,4 @@ class OntonotesReader(PackReader):
                 group_id = int(segment[:-1])
                 start = coref_stacks[group_id].pop()
                 coref_mention = EntityMention(pack, start, word_end)
-                coref_mention = pack.add_or_get_entry(coref_mention)
-
                 groups[group_id].append(coref_mention)

--- a/forte/data/readers/plaintext_reader.py
+++ b/forte/data/readers/plaintext_reader.py
@@ -57,8 +57,7 @@ class PlainTextReader(PackReader):
 
         pack.set_text(text, replace_func=self.text_replace_operation)
 
-        document = Document(pack, 0, len(pack.text))
-        pack.add_or_get_entry(document)
+        Document(pack, 0, len(pack.text))
 
         pack.meta.doc_id = file_path
         yield pack

--- a/forte/data/readers/prodigy_reader.py
+++ b/forte/data/readers/prodigy_reader.py
@@ -62,13 +62,13 @@ class ProdigyReader(PackReader):
         """
         pack = DataPack()
         text = data['text']
-        tokens = data['tokens']
-        spans = data['spans']
+        pack.set_text(text, replace_func=self.text_replace_operation)
 
         document = Document(pack, 0, len(text))
-        pack.set_text(text, replace_func=self.text_replace_operation)
         pack.add_or_get_entry(document)
 
+        tokens = data['tokens']
+        spans = data['spans']
         for token in tokens:
             begin = token['start']
             end = token['end']

--- a/forte/data/readers/prodigy_reader.py
+++ b/forte/data/readers/prodigy_reader.py
@@ -64,23 +64,20 @@ class ProdigyReader(PackReader):
         text = data['text']
         pack.set_text(text, replace_func=self.text_replace_operation)
 
-        document = Document(pack, 0, len(text))
-        pack.add_or_get_entry(document)
+        Document(pack, 0, len(text))
 
         tokens = data['tokens']
         spans = data['spans']
         for token in tokens:
             begin = token['start']
             end = token['end']
-            token_entry = Token(pack, begin, end)
-            pack.add_or_get_entry(token_entry)
+            Token(pack, begin, end)
 
         for span_items in spans:
             begin = span_items['start']
             end = span_items['end']
             annotation_entry = EntityMention(pack, begin, end)
             annotation_entry.ner_type = span_items['label']
-            pack.add_or_get_entry(annotation_entry)
 
         pack.meta.doc_id = data['meta']['id']
 

--- a/forte/data/readers/race_multi_choice_qa_reader.py
+++ b/forte/data/readers/race_multi_choice_qa_reader.py
@@ -79,7 +79,6 @@ class RACEMultiChoiceQAReader(PackReader):
                     option_end = offset + len(option_text)
                     option = Option(pack, offset, option_end)
                     options.append(option)
-                    pack.add_entry(option)
                     offset = option_end + 1
                 question.options = options
 
@@ -88,17 +87,14 @@ class RACEMultiChoiceQAReader(PackReader):
                     answers = [answers]
                 answers = [self._convert_to_int(ans) for ans in answers]
                 question.answers = answers
-                pack.add_entry(question)
 
             pack.set_text(text, replace_func=self.text_replace_operation)
 
-            article = RaceDocument(pack, 0, article_end)
-            pack.add_entry(article)
+            RaceDocument(pack, 0, article_end)
 
             passage_id: str = dataset['id']
             passage = Passage(pack, 0, len(pack.text))
             passage.passage_id = passage_id
-            pack.add_entry(passage)
 
             pack.meta.doc_id = passage_id
             yield pack

--- a/forte/data/readers/race_multi_choice_qa_reader.py
+++ b/forte/data/readers/race_multi_choice_qa_reader.py
@@ -64,8 +64,6 @@ class RACEMultiChoiceQAReader(PackReader):
             pack = DataPack()
             text: str = dataset['article']
             article_end = len(text)
-            article = RaceDocument(pack, 0, article_end)
-            pack.add_entry(article)
             offset = article_end + 1
 
             for qid, ques_text in enumerate(dataset['questions']):
@@ -93,6 +91,9 @@ class RACEMultiChoiceQAReader(PackReader):
                 pack.add_entry(question)
 
             pack.set_text(text, replace_func=self.text_replace_operation)
+
+            article = RaceDocument(pack, 0, article_end)
+            pack.add_entry(article)
 
             passage_id: str = dataset['id']
             passage = Passage(pack, 0, len(pack.text))

--- a/forte/data/readers/string_reader.py
+++ b/forte/data/readers/string_reader.py
@@ -31,6 +31,7 @@ __all__ = [
 class StringReader(PackReader):
     r""":class:`StringReader` is designed to read in a list of string variables.
     """
+
     # pylint: disable=unused-argument
     def _cache_key_function(self, collection) -> str:
         return str(hash(collection)) + '.html'
@@ -57,9 +58,7 @@ class StringReader(PackReader):
         """
         pack = DataPack()
 
-        document = Document(pack, 0, len(data_source))
-        pack.add_or_get_entry(document)
-
         self.set_text(pack, data_source)
+        Document(pack, 0, len(data_source))
 
         yield pack

--- a/forte/data/selector.py
+++ b/forte/data/selector.py
@@ -63,32 +63,6 @@ class SinglePackSelector(Selector[MultiPack, DataPack]):
         raise NotImplementedError
 
 
-class MultiPackBoxer(Selector[DataPack, MultiPack]):
-    """
-    This class creates a Dummy MultiPack from DataPack.
-
-    Attributes:
-        pack_name: The pack name that will be assigned to the data pack when
-            it is boxed to the multi pack.
-    """
-
-    def __init__(self, pack_name: str):
-        super().__init__()
-        self.pack_name = pack_name
-
-    def select(self, pack: DataPack) -> Iterator[MultiPack]:
-        """
-        Args:
-            pack: The data pack to be boxed
-
-        Returns: An iterator that produces the boxed multi pack.
-
-        """
-        p = MultiPack()
-        p.add_pack(self.pack_name)
-        yield p
-
-
 class NameMatchSelector(SinglePackSelector):
     r"""Select a :class:`DataPack` from a :class:`MultiPack` with specified
     name.

--- a/forte/data/selector.py
+++ b/forte/data/selector.py
@@ -71,6 +71,7 @@ class MultiPackBoxer(Selector[DataPack, MultiPack]):
         pack_name: The pack name that will be assigned to the data pack when
             it is boxed to the multi pack.
     """
+
     def __init__(self, pack_name: str):
         super().__init__()
         self.pack_name = pack_name
@@ -84,7 +85,7 @@ class MultiPackBoxer(Selector[DataPack, MultiPack]):
 
         """
         p = MultiPack()
-        p.add_pack(pack, self.pack_name)
+        p.add_pack(self.pack_name)
         yield p
 
 

--- a/forte/indexers/embedding_based_indexer.py
+++ b/forte/indexers/embedding_based_indexer.py
@@ -48,13 +48,13 @@ class EmbeddingBasedIndexer:
 
     def __init__(self, config: Optional[Union[Dict, Config]] = None):
         super().__init__()
-        self._hparams = Config(hparams=config,
-                               default_hparams=self.default_configs())
+        self._config = Config(hparams=config,
+                              default_hparams=self.default_configs())
         self._meta_data: Dict[int, str] = {}
 
-        index_type = self._hparams.index_type
-        device = self._hparams.device
-        dim = self._hparams.dim
+        index_type = self._config.index_type
+        device = self._config.device
+        dim = self._config.dim
 
         if device.lower().startswith("gpu"):
             if isinstance(index_type, str) and not index_type.startswith("Gpu"):
@@ -68,7 +68,7 @@ class EmbeddingBasedIndexer:
                 logging.warning("Cannot create the index on device %s. "
                                 "Total number of GPUs on this machine is "
                                 "%s. Using gpu0 for the index.",
-                                self._hparams.device, faiss.get_num_gpus())
+                                self._config.device, faiss.get_num_gpus())
             config_class_name = \
                 self.INDEX_TYPE_TO_CONFIG.get(index_class.__name__)
             config = utils.get_class(config_class_name,  # type: ignore
@@ -203,7 +203,7 @@ class EmbeddingBasedIndexer:
         cpu_index = faiss.read_index(f"{path}/index.faiss")
 
         if device is None:
-            device = self._hparams.device
+            device = self._config.device
 
         if device.lower().startswith("gpu"):
             gpu_resource = faiss.StandardGpuResources()

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -458,9 +458,12 @@ class Pipeline(Generic[PackType]):
                             processor.process(pack)
                         elif isinstance(processor, Evaluator):
                             processor.consume_next(
-                                pack,
-                                self._predict_to_gold[unprocessed_job.id]
+                                pack, self._predict_to_gold[unprocessed_job.id]
                             )
+
+                        # After the component action, make sure the entry is
+                        # added into the index.
+                        pack.add_all_remaining_entry()
                     except Exception as e:
                         raise ProcessExecutionException(
                             f'Exception occurred when running '
@@ -468,8 +471,7 @@ class Pipeline(Generic[PackType]):
 
                     # Then, based on component type, handle the queue.
                     if isinstance(processor, BaseBatchProcessor):
-                        index = \
-                            unprocessed_queue_indices[current_queue_index]
+                        index = unprocessed_queue_indices[current_queue_index]
 
                         # check status of all the jobs up to "index"
                         for i, job_i in enumerate(
@@ -580,7 +582,6 @@ class Pipeline(Generic[PackType]):
 
                 # current queue is modified in the loop
                 for job in list(current_queue):
-
                     if job.status != ProcessJobStatus.PROCESSED and \
                             not job.is_poison:
                         raise ValueError("Job is neither PROCESSED nor is "

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -463,7 +463,7 @@ class Pipeline(Generic[PackType]):
 
                         # After the component action, make sure the entry is
                         # added into the index.
-                        pack.add_all_remaining_entry()
+                        pack.add_all_remaining_entries()
                     except Exception as e:
                         raise ProcessExecutionException(
                             f'Exception occurred when running '

--- a/forte/pipeline_component.py
+++ b/forte/pipeline_component.py
@@ -17,6 +17,7 @@ Pipeline component module.
 from typing import Generic, Optional, Union, Dict, Any
 
 import yaml
+from forte.common import ProcessorConfigError
 
 from forte.common.configuration import Config
 from forte.common.resources import Resources
@@ -105,7 +106,13 @@ class PipelineComponent(Generic[PackType]):
 
             merged_configs.update(configs)
 
-        final_configs = Config(merged_configs, cls.default_configs())
+        try:
+            final_configs = Config(merged_configs, cls.default_configs())
+        except ValueError as e:
+            raise ProcessorConfigError(
+                f'Configuration error for the processor '
+                f'{get_full_module_name(cls)}.') from e
+
         return final_configs
 
     @classmethod

--- a/forte/processors/allennlp_processors.py
+++ b/forte/processors/allennlp_processors.py
@@ -140,7 +140,6 @@ class AllenNLPProcessor(PackProcessor):
             if "pos" in self.configs.processors:
                 token.pos = pos[i]
             tokens.append(token)
-            input_pack.add_entry(token)
 
         return tokens
 
@@ -153,4 +152,3 @@ class AllenNLPProcessor(PackProcessor):
                                   parent=tokens[heads[i] - 1],
                                   child=token)
             relation.rel_type = deps[i]
-            input_pack.add_or_get_entry(relation)

--- a/forte/processors/annotation_remover.py
+++ b/forte/processors/annotation_remover.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict
+
+from forte.data.data_pack import DataPack
+from forte.processors.base import PackProcessor
+from forte.utils import get_class
+
+
+class AnnotationRemover(PackProcessor):
+    def _process(self, input_pack: DataPack):
+        for type_name in self.configs.removal_types:
+            type_cls = get_class(type_name)
+
+            for t in input_pack.get(type_cls):
+                input_pack.delete_entry(t)
+
+    @classmethod
+    def default_configs(cls) -> Dict[str, Any]:
+        config = super().default_configs()
+        config.update({
+            'removal_types': []
+        })
+        return config

--- a/forte/processors/base/base_processor.py
+++ b/forte/processors/base/base_processor.py
@@ -48,7 +48,6 @@ class BaseProcessor(PipelineComponent[PackType], ABC):
         u_index = self._process_manager.unprocessed_queue_indices[q_index]
         current_queue = self._process_manager.current_queue
 
-        # TODO: Can we do this?
         for job_i in itertools.islice(current_queue, 0, u_index + 1):
             if job_i.status == ProcessJobStatus.UNPROCESSED:
                 job_i.set_status(ProcessJobStatus.PROCESSED)
@@ -64,12 +63,6 @@ class BaseProcessor(PipelineComponent[PackType], ABC):
             input_pack: The input datapack.
         """
         raise NotImplementedError
-
-    def flush(self):
-        r"""Indicate that there will be no more packs to be passed in, handle
-        what's remaining in the buffer.
-        """
-        pass
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:

--- a/forte/processors/base/base_processor.py
+++ b/forte/processors/base/base_processor.py
@@ -48,6 +48,7 @@ class BaseProcessor(PipelineComponent[PackType], ABC):
         u_index = self._process_manager.unprocessed_queue_indices[q_index]
         current_queue = self._process_manager.current_queue
 
+        # TODO: Can we do this?
         for job_i in itertools.islice(current_queue, 0, u_index + 1):
             if job_i.status == ProcessJobStatus.UNPROCESSED:
                 job_i.set_status(ProcessJobStatus.PROCESSED)

--- a/forte/processors/base/batch_processor.py
+++ b/forte/processors/base/batch_processor.py
@@ -109,7 +109,7 @@ class BaseBatchProcessor(BaseProcessor[PackType], ABC):
         function is implemented to convert the input datapacks into batches
         according to the Batcher. Users do not need to implement this function
         but should instead implement ``predict``, which computes results from
-        batches, and ``pack``, which convert the batch results back to
+        batches, and ``pack_all``, which convert the batch results back to
         datapacks.
 
         Args:
@@ -175,6 +175,7 @@ class BaseBatchProcessor(BaseProcessor[PackType], ABC):
                                         self.batcher.current_batch_sources[i])
             self.pack(self.batcher.data_pack_pool[i], output_dict_i)
             start += self.batcher.current_batch_sources[i]
+            # pack_i.add_all_remaining_entry()
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:

--- a/forte/processors/base/batch_processor.py
+++ b/forte/processors/base/batch_processor.py
@@ -171,11 +171,12 @@ class BaseBatchProcessor(BaseProcessor[PackType], ABC):
         """
         start = 0
         for i in range(len(self.batcher.data_pack_pool)):
+            pack_i = self.batcher.data_pack_pool[i]
             output_dict_i = slice_batch(output_dict, start,
                                         self.batcher.current_batch_sources[i])
-            self.pack(self.batcher.data_pack_pool[i], output_dict_i)
+            self.pack(pack_i, output_dict_i)
             start += self.batcher.current_batch_sources[i]
-            # pack_i.add_all_remaining_entry()
+            pack_i.add_all_remaining_entries()
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:

--- a/forte/processors/base/query_processor.py
+++ b/forte/processors/base/query_processor.py
@@ -70,4 +70,4 @@ class QueryProcessor(BasePackProcessor[PackType], ABC):
     def _process(self, input_pack: PackType):
         query_pack, query_value = self._process_query(input_pack)
         query = Query(pack=query_pack)
-        query.set_value(value=query_value)
+        query.value = query_value

--- a/forte/processors/base/query_processor.py
+++ b/forte/processors/base/query_processor.py
@@ -71,4 +71,3 @@ class QueryProcessor(BasePackProcessor[PackType], ABC):
         query_pack, query_value = self._process_query(input_pack)
         query = Query(pack=query_pack)
         query.set_value(value=query_value)
-        query_pack.add_entry(query)

--- a/forte/processors/ir/bert_based_query_creator.py
+++ b/forte/processors/ir/bert_based_query_creator.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # pylint: disable=attribute-defined-outside-init
 import pickle
 from typing import Any, Dict, Tuple

--- a/forte/processors/ir/bert_based_query_creator.py
+++ b/forte/processors/ir/bert_based_query_creator.py
@@ -67,7 +67,8 @@ class BertBasedQueryCreator(QueryProcessor[MultiPack]):
         config = super().default_configs()
         config.update({
             "model": {
-                "name": "bert-base-uncased"
+                'path': None,
+                "name": "bert-base-uncased",
             },
             "tokenizer": {
                 "name": "bert-base-uncased"

--- a/forte/processors/ir/elastic_search_processor.py
+++ b/forte/processors/ir/elastic_search_processor.py
@@ -83,5 +83,4 @@ class ElasticSearchProcessor(MultiPackProcessor):
             content = document[self.config.field]
             pack.set_text(content)
 
-            document = Document(pack=pack, begin=0, end=len(content))
-            pack.add_entry(document)
+            Document(pack=pack, begin=0, end=len(content))

--- a/forte/processors/ir/search_processor.py
+++ b/forte/processors/ir/search_processor.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 # pylint: disable=attribute-defined-outside-init
+from typing import Dict, Any
+
 from forte.common.configuration import Config
 from forte.common.resources import Resources
-from forte.data.data_pack import DataPack
 from forte.data.multi_pack import MultiPack
 from forte.data.ontology.top import Query
+from forte.indexers import EmbeddingBasedIndexer
 from forte.processors.base import MultiPackProcessor
-from forte.indexers.embedding_based_indexer import EmbeddingBasedIndexer
-
 from ft.onto.base_ontology import Document
 
 __all__ = [
@@ -54,10 +54,20 @@ class SearchProcessor(MultiPackProcessor):
 
         packs = {}
         for i, doc in enumerate(documents):
-            pack = DataPack()
-            document = Document(pack=pack, begin=0, end=len(doc))
-            pack.add_entry(document)
+            pack = input_pack.add_pack()
             pack.set_text(doc)
-            packs[self.config.response_pack_name[i]] = pack
+
+            document = Document(pack, 0, len(doc))
+            pack.add_entry(document)
+            packs[self.config.response_pack_name_prefix + f'_{i}'] = pack
 
         input_pack.update_pack(packs)
+
+    @classmethod
+    def default_configs(cls) -> Dict[str, Any]:
+        config = super().default_configs()
+        config.update({
+            'model_dir': None,
+            'response_pack_name_prefix': 'doc'
+        })
+        return config

--- a/forte/processors/ir/search_processor.py
+++ b/forte/processors/ir/search_processor.py
@@ -57,8 +57,7 @@ class SearchProcessor(MultiPackProcessor):
             pack = input_pack.add_pack()
             pack.set_text(doc)
 
-            document = Document(pack, 0, len(doc))
-            pack.add_entry(document)
+            Document(pack, 0, len(doc))
             packs[self.config.response_pack_name_prefix + f'_{i}'] = pack
 
         input_pack.update_pack(packs)

--- a/forte/processors/machine_translation_processor.py
+++ b/forte/processors/machine_translation_processor.py
@@ -14,7 +14,7 @@
 # pylint: disable=attribute-defined-outside-init
 import uuid
 from os import getenv
-from typing import Optional
+from typing import Optional, Dict, Any
 from urllib.parse import urlencode
 
 import requests
@@ -96,12 +96,22 @@ class MicrosoftBingTranslator(MultiPackProcessor):
             raise RuntimeError(response.json()['error']['message'])
 
         text = response.json()[0]["translations"][0]["text"]
-        pack = DataPack()
+        pack: DataPack = input_pack.add_pack(self.out_pack_name)
+        pack.set_text(text=text)
 
         document = Document(pack, 0, len(text))
-        utterance = Utterance(pack, 0, len(text))
         pack.add_entry(document)
+
+        utterance = Utterance(pack, 0, len(text))
         pack.add_entry(utterance)
 
-        pack.set_text(text=text)
-        input_pack.update_pack({self.out_pack_name: pack})
+    @classmethod
+    def default_configs(cls) -> Dict[str, Any]:
+        config = super().default_configs()
+        config.update({
+            'src_language': 'en',
+            'target_language': 'de',
+            'in_pack_name': 'doc_0',
+            'out_pack_name': 'response',
+        })
+        return config

--- a/forte/processors/machine_translation_processor.py
+++ b/forte/processors/machine_translation_processor.py
@@ -99,11 +99,8 @@ class MicrosoftBingTranslator(MultiPackProcessor):
         pack: DataPack = input_pack.add_pack(self.out_pack_name)
         pack.set_text(text=text)
 
-        document = Document(pack, 0, len(text))
-        pack.add_entry(document)
-
-        utterance = Utterance(pack, 0, len(text))
-        pack.add_entry(utterance)
+        Document(pack, 0, len(text))
+        Utterance(pack, 0, len(text))
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:

--- a/forte/processors/ner_predictor.py
+++ b/forte/processors/ner_predictor.py
@@ -206,13 +206,11 @@ class CoNLLNERPredictor(FixedSizeBatchProcessor):
                                            current_entity_mention[0],
                                            token.span.end)
                     entity.ner_type = current_entity_mention[1]
-                    data_pack.add_or_get_entry(entity)
                 elif token_ner[0] == "S":
                     current_entity_mention = (token.span.begin, token_ner[2:])
                     entity = EntityMention(data_pack, current_entity_mention[0],
                                            token.span.end)
                     entity.ner_type = current_entity_mention[1]
-                    data_pack.add_or_get_entry(entity)
 
     def get_batch_tensor(
             self, data: List[Tuple[List[int], List[List[int]]]],

--- a/forte/processors/nltk_processors.py
+++ b/forte/processors/nltk_processors.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nltk import word_tokenize, pos_tag, sent_tokenize, ne_chunk
+from nltk import pos_tag, ne_chunk, PunktSentenceTokenizer
 from nltk.chunk import RegexpParser
 from nltk.stem import WordNetLemmatizer
+from nltk.tokenize.treebank import TreebankWordTokenizer
 
 from forte.common.configuration import Config
 from forte.common.resources import Resources
@@ -38,18 +39,11 @@ class NLTKWordTokenizer(PackProcessor):
 
     def __init__(self):
         super().__init__()
-        self.sentence_component = None
+        self.tokenizer = TreebankWordTokenizer()
 
     def _process(self, input_pack: DataPack):
-        for sentence in input_pack.get(entry_type=Sentence,
-                                       component=self.sentence_component):
-            offset = sentence.span.begin
-            end_pos = 0
-            for word in word_tokenize(sentence.text):
-                begin_pos = sentence.text.find(word, end_pos)
-                end_pos = begin_pos + len(word)
-                token = Token(input_pack, begin_pos + offset, end_pos + offset)
-                input_pack.add_or_get_entry(token)
+        for begin, end in self.tokenizer.span_tokenize(input_pack.text):
+            Token(input_pack, begin, end)
 
 
 class NLTKPOSTagger(PackProcessor):
@@ -61,14 +55,12 @@ class NLTKPOSTagger(PackProcessor):
         self.token_component = None
 
     def _process(self, input_pack: DataPack):
-        for sentence in input_pack.get(Sentence):
-            token_entries = list(input_pack.get(entry_type=Token,
-                                                range_annotation=sentence,
-                                                component=self.token_component))
-            token_texts = [token.text for token in token_entries]
-            taggings = pos_tag(token_texts)
-            for token, tag in zip(token_entries, taggings):
-                token.pos = tag[1]
+        token_entries = list(input_pack.get(entry_type=Token,
+                                            component=self.token_component))
+        token_texts = [token.text for token in token_entries]
+        taggings = pos_tag(token_texts)
+        for token, tag in zip(token_entries, taggings):
+            token.pos = tag[1]
 
 
 class NLTKLemmatizer(PackProcessor):
@@ -81,16 +73,14 @@ class NLTKLemmatizer(PackProcessor):
         self.lemmatizer = WordNetLemmatizer()
 
     def _process(self, input_pack: DataPack):
-        for sentence in input_pack.get(Sentence):
-            token_entries = list(input_pack.get(entry_type=Token,
-                                                range_annotation=sentence,
-                                                component=self.token_component))
-            token_texts = [token.text for token in token_entries]
-            token_pos = [penn2morphy(token.pos) for token in token_entries]
-            lemmas = [self.lemmatizer.lemmatize(token_texts[i], token_pos[i])
-                      for i in range(len(token_texts))]
-            for token, lemma in zip(token_entries, lemmas):
-                token.lemma = lemma
+        token_entries = list(input_pack.get(entry_type=Token,
+                                            component=self.token_component))
+        token_texts = [token.text for token in token_entries]
+        token_pos = [penn2morphy(token.pos) for token in token_entries]
+        lemmas = [self.lemmatizer.lemmatize(token_texts[i], token_pos[i])
+                  for i in range(len(token_texts))]
+        for token, lemma in zip(token_entries, lemmas):
+            token.lemma = lemma
 
 
 def penn2morphy(penntag: str) -> str:
@@ -110,7 +100,6 @@ class NLTKChunker(PackProcessor):
     def __init__(self):
         super().__init__()
         self.chunker = None
-        self.token_component = None
 
     # pylint: disable=unused-argument
     def initialize(self, resources: Resources, configs: Config):
@@ -123,14 +112,18 @@ class NLTKChunker(PackProcessor):
         config = super().default_configs()
         config.update({
             'pattern': 'NP: {<DT>?<JJ>*<NN>}',
+            'token_component': None,
+            'sentence_component': None
         })
         return config
 
     def _process(self, input_pack: DataPack):
-        for sentence in input_pack.get(Sentence):
-            token_entries = list(input_pack.get(entry_type=Token,
-                                                range_annotation=sentence,
-                                                component=self.token_component))
+        for sentence in input_pack.get(
+                Sentence, component=self.configs.sentence_component):
+            token_entries = list(input_pack.get(
+                entry_type=Token, range_annotation=sentence,
+                component=self.configs.token_component))
+
             tokens = [(token.text, token.pos) for token in token_entries]
             cs = self.chunker.parse(tokens)
 
@@ -143,7 +136,6 @@ class NLTKChunker(PackProcessor):
                     end_pos = token_entries[index + len(chunk) - 1].span.end
                     phrase = Phrase(input_pack, begin_pos, end_pos)
                     phrase.phrase_type = chunk.label()
-                    input_pack.add_or_get_entry(phrase)
 
                     index += len(chunk)
                 else:
@@ -156,17 +148,13 @@ class NLTKSentenceSegmenter(PackProcessor):
     r"""A wrapper of NLTK sentence tokenizer.
     """
 
+    def __init__(self):
+        super().__init__()
+        self.sent_splitter = PunktSentenceTokenizer()
+
     def _process(self, input_pack: DataPack):
-        text = input_pack.text
-        end_pos = 0
-        paragraphs = [p for p in text.split('\n') if p]
-        for paragraph in paragraphs:
-            sentences = sent_tokenize(paragraph)
-            for sentence_text in sentences:
-                begin_pos = text.find(sentence_text, end_pos)
-                end_pos = begin_pos + len(sentence_text)
-                sentence_entry = Sentence(input_pack, begin_pos, end_pos)
-                input_pack.add_or_get_entry(sentence_entry)
+        for begin, end in self.sent_splitter.span_tokenize(input_pack.text):
+            Sentence(input_pack, begin, end)
 
 
 class NLTKNER(PackProcessor):
@@ -194,7 +182,6 @@ class NLTKNER(PackProcessor):
                     end_pos = token_entries[index + len(chunk) - 1].span.end
                     entity = EntityMention(input_pack, begin_pos, end_pos)
                     entity.ner_type = chunk.label()
-                    input_pack.add_or_get_entry(entity)
                     index += len(chunk)
                 else:
                     # For example:

--- a/forte/processors/nltk_processors.py
+++ b/forte/processors/nltk_processors.py
@@ -103,6 +103,7 @@ class NLTKChunker(PackProcessor):
 
     # pylint: disable=unused-argument
     def initialize(self, resources: Resources, configs: Config):
+        super().initialize(resources, configs)
         self.chunker = RegexpParser(configs.pattern)
 
     @classmethod

--- a/forte/processors/spacy_processors.py
+++ b/forte/processors/spacy_processors.py
@@ -81,10 +81,7 @@ class SpacyProcessor(PackProcessor):
 
         """
         for sentence in sentences:
-            sentence_entry = Sentence(input_pack,
-                                      sentence.start_char,
-                                      sentence.end_char)
-            input_pack.add_or_get_entry(sentence_entry)
+            Sentence(input_pack, sentence.start_char, sentence.end_char)
 
             if "tokenize" in self.processors:
                 # Iterating through spaCy token objects
@@ -98,8 +95,6 @@ class SpacyProcessor(PackProcessor):
 
                     if "lemma" in self.processors:
                         token.lemma = word.lemma_
-
-                    input_pack.add_or_get_entry(token)
 
     def _process_ner(self, result, input_pack):
         """Perform spaCy's NER Pipeline on the document.
@@ -115,7 +110,6 @@ class SpacyProcessor(PackProcessor):
             entity = EntityMention(input_pack, item.start_char,
                                    item.end_char)
             entity.ner_type = item.label_
-            input_pack.add_or_get_entry(entity)
 
     def _process(self, input_pack: DataPack):
         doc = input_pack.text

--- a/forte/processors/srl_predictor.py
+++ b/forte/processors/srl_predictor.py
@@ -151,7 +151,7 @@ class SRLPredictor(FixedSizeBatchProcessor):
         This defines a basic config structure
         :return:
         """
-        configs = super(cls).default_configs()
+        configs = super().default_configs()
         configs.update({
             'storage_path': None,
             "batcher": {

--- a/forte/processors/srl_predictor.py
+++ b/forte/processors/srl_predictor.py
@@ -132,18 +132,15 @@ class SRLPredictor(FixedSizeBatchProcessor):
         for predictions in batch_predictions:
             for pred_span, arg_result in predictions:
 
-                pred = data_pack.add_entry(PredicateMention(
-                    data_pack, pred_span.begin, pred_span.end)
-                )
+                pred = PredicateMention(data_pack, pred_span.begin,
+                                        pred_span.end)
 
                 for arg_span, label in arg_result:
-                    arg = data_pack.add_or_get_entry(PredicateArgument(
+                    arg = PredicateArgument(
                         data_pack, arg_span.begin, arg_span.end
-                    )
                     )
                     link = PredicateLink(data_pack, pred, arg)
                     link.arg_type = label
-                    data_pack.add_or_get_entry(link)
 
     @classmethod
     def default_configs(cls):

--- a/forte/processors/stanfordnlp_processor.py
+++ b/forte/processors/stanfordnlp_processor.py
@@ -75,7 +75,6 @@ class StandfordNLPProcessor(PackProcessor):
             end_pos = doc.find(sentence.words[-1].text, begin_pos) + len(
                 sentence.words[-1].text)
             sentence_entry = Sentence(input_pack, begin_pos, end_pos)
-            input_pack.add_or_get_entry(sentence_entry)
 
             tokens: List[Token] = []
             if "tokenize" in self.processors:
@@ -99,7 +98,6 @@ class StandfordNLPProcessor(PackProcessor):
                     if "lemma" in self.processors:
                         token.lemma = word.lemma
 
-                    token = input_pack.add_or_get_entry(token)
                     tokens.append(token)
 
             # For each sentence, get the dependency relations among tokens
@@ -110,5 +108,3 @@ class StandfordNLPProcessor(PackProcessor):
                     parent = tokens[word.governor - 1]  # Root token
                     relation_entry = Dependency(input_pack, parent, child)
                     relation_entry.rel_type = word.dependency_relation
-
-                    input_pack.add_or_get_entry(relation_entry)

--- a/forte/processors/text_generation_processor.py
+++ b/forte/processors/text_generation_processor.py
@@ -177,7 +177,6 @@ class TextGenerationProcessor(MultiPackBatchProcessor):
         for input_id, output_sentence in zip(input_sent_tids, output_sentences):
             offset = len(output_pack.text)
             sent = Sentence(output_pack, offset, offset + len(output_sentence))
-            output_pack.add_entry(sent)
             text += output_sentence + "\n"
 
             input_sent = input_pack.get_entry(input_id)

--- a/ft/onto/race_multi_choice_qa_ontology.py
+++ b/ft/onto/race_multi_choice_qa_ontology.py
@@ -88,7 +88,7 @@ class Question(Annotation):
     @options.setter
     def options(self, options: Optional[List[Option]]):
         options = [] if options is None else options
-        self.set_fields(_options=[self.pack.add_entry_(obj) for obj in options])
+        self.set_fields(_options=[obj.tid for obj in options])
 
     def num_options(self):
         return len(self._options)
@@ -98,7 +98,7 @@ class Question(Annotation):
         self._options.clear()
 
     def add_options(self, a_options: Option):
-        self._options.append(self.pack.add_entry_(a_options))
+        self._options.append(a_options.tid)
 
     @property
     def answers(self):

--- a/tests/dummy_batch_processor.py
+++ b/tests/dummy_batch_processor.py
@@ -107,7 +107,6 @@ class DummyRelationExtractor(BatchProcessor):
                 child: EntityMention = data_pack.get_entry(  # type: ignore
                     output_dict["RelationLink"]["child.tid"][i][j])
                 link.set_child(child)
-                data_pack.add_or_get_entry(link)
 
     @classmethod
     def default_configs(cls):

--- a/tests/forte/data/container_test.py
+++ b/tests/forte/data/container_test.py
@@ -22,11 +22,12 @@ import pickle
 import tempfile
 
 from forte.data.container import EntryContainer
+from forte.data.ontology.core import Entry
 from forte.data.span import Span
 
 
 class DummyContainer(EntryContainer):
-    def add_entry_creation_record(self, entry_id: int):
+    def record_new_entry(self, entry: Entry):
         pass
 
     def add_field_record(self, entry_id: int, field_name: str):

--- a/tests/forte/data/container_test.py
+++ b/tests/forte/data/container_test.py
@@ -21,12 +21,15 @@ import os
 import pickle
 import tempfile
 
-from forte.data.container import EntryContainer
+from forte.data.container import EntryContainer, E
 from forte.data.ontology.core import Entry
 from forte.data.span import Span
 
 
 class DummyContainer(EntryContainer):
+    def regret_record(self, entry: E):
+        pass
+
     def record_new_entry(self, entry: Entry):
         pass
 

--- a/tests/forte/data/multi_pack_test.py
+++ b/tests/forte/data/multi_pack_test.py
@@ -7,6 +7,7 @@ import unittest
 from forte.data.multi_pack import MultiPack, MultiPackLink
 from forte.data.data_pack import DataPack
 from forte.data.ontology import Annotation
+from forte.pack_manager import PackManager
 from ft.onto.base_ontology import (
     Token)
 
@@ -17,16 +18,19 @@ def _space_token(pack: DataPack):
     begin = 0
     for i, c in enumerate(pack.text):
         if c == ' ':
-            Token(pack, begin, i)
+            pack.add_entry(Token(pack, begin, i))
             begin = i + 1
 
     if begin < len(pack.text):
-        Token(pack, begin, len(pack.text))
+        pack.add_entry(Token(pack, begin, len(pack.text)))
 
 
 class DataPackTest(unittest.TestCase):
 
     def setUp(self) -> None:
+        # Note: input source is created automatically by the system, but we
+        #  can also set it manually at test cases.
+        PackManager().set_input_source('test case')
         self.multi_pack = MultiPack()
         self.data_pack1 = self.multi_pack.add_pack(pack_name="left pack")
         self.data_pack2 = self.multi_pack.add_pack(pack_name="right pack")

--- a/tests/forte/data/multi_pack_test.py
+++ b/tests/forte/data/multi_pack_test.py
@@ -17,11 +17,11 @@ def _space_token(pack: DataPack):
     begin = 0
     for i, c in enumerate(pack.text):
         if c == ' ':
-            pack.add_entry(Token(pack, begin, i))
+            Token(pack, begin, i)
             begin = i + 1
 
     if begin < len(pack.text):
-        pack.add_entry(Token(pack, begin, len(pack.text)))
+        Token(pack, begin, len(pack.text))
 
 
 class DataPackTest(unittest.TestCase):

--- a/tests/forte/data/multi_pack_test.py
+++ b/tests/forte/data/multi_pack_test.py
@@ -27,24 +27,24 @@ def _space_token(pack: DataPack):
 class DataPackTest(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.data_pack1 = DataPack(doc_id="some pack")
-        self.data_pack1.set_text("This pack contains some sample data.")
-        self.data_pack2 = DataPack(doc_id="another pack")
-        self.data_pack2.set_text("This pack contains some other sample data.")
-
         self.multi_pack = MultiPack()
-        self.multi_pack.add_pack(self.data_pack1, pack_name="left pack")
-        self.multi_pack.add_pack(self.data_pack2, pack_name="right pack")
+        self.data_pack1 = self.multi_pack.add_pack(pack_name="left pack")
+        self.data_pack2 = self.multi_pack.add_pack(pack_name="right pack")
+
+        self.data_pack1.doc_id = "some pack"
+        self.data_pack1.set_text("This pack contains some sample data.")
+
+        self.data_pack2.doc_id = "another pack"
+        self.data_pack2.set_text("This pack contains some other sample data.")
 
     def test_serialization(self):
         ser_str: str = self.multi_pack.serialize()
         print(ser_str)
 
     def test_add_pack(self):
-        data_pack3 = DataPack(doc_id="the third pack")
+        data_pack3 = self.multi_pack.add_pack(pack_name="new pack")
+        data_pack3.doc_id = "the third pack"
         data_pack3.set_text("Test to see if we can add new packs..")
-
-        self.multi_pack.add_pack(data_pack3, pack_name="new pack")
 
         self.assertEqual(len(self.multi_pack.packs), 3)
         self.assertEqual(self.multi_pack.pack_names,

--- a/tests/forte/data/ontology/test_outputs/ft/onto/example_complex_ontology.py
+++ b/tests/forte/data/ontology/test_outputs/ft/onto/example_complex_ontology.py
@@ -111,7 +111,7 @@ class Sentence(Annotation):
     @key_tokens.setter
     def key_tokens(self, key_tokens: Optional[List[Token]]):
         key_tokens = [] if key_tokens is None else key_tokens
-        self.set_fields(_key_tokens=[self.pack.add_entry_(obj) for obj in key_tokens])
+        self.set_fields(_key_tokens=[obj.tid for obj in key_tokens])
 
     def num_key_tokens(self):
         return len(self._key_tokens)
@@ -121,7 +121,7 @@ class Sentence(Annotation):
         self._key_tokens.clear()
 
     def add_key_tokens(self, a_key_tokens: Token):
-        self._key_tokens.append(self.pack.add_entry_(a_key_tokens))
+        self._key_tokens.append(a_key_tokens.tid)
 
 
 class Document(Annotation):

--- a/tests/forte/data/ontology/test_outputs/ft/onto/example_ontology.py
+++ b/tests/forte/data/ontology/test_outputs/ft/onto/example_ontology.py
@@ -73,7 +73,7 @@ class Word(Token):
     @word_forms.setter
     def word_forms(self, word_forms: Optional[List["Word"]]):
         word_forms = [] if word_forms is None else word_forms
-        self.set_fields(_word_forms=[self.pack.add_entry_(obj) for obj in word_forms])
+        self.set_fields(_word_forms=[obj.tid for obj in word_forms])
 
     def num_word_forms(self):
         return len(self._word_forms)
@@ -83,7 +83,7 @@ class Word(Token):
         self._word_forms.clear()
 
     def add_word_forms(self, a_word_forms: "Word"):
-        self._word_forms.append(self.pack.add_entry_(a_word_forms))
+        self._word_forms.append(a_word_forms.tid)
 
     @property
     def token_ranks(self):
@@ -92,7 +92,7 @@ class Word(Token):
     @token_ranks.setter
     def token_ranks(self, token_ranks: Optional[Dict[int, "Word"]]):
         token_ranks = {} if token_ranks is None else token_ranks
-        self.set_fields(_token_ranks=dict([(k, self.pack.add_entry_(v)) for k, v in token_ranks.items()]))
+        self.set_fields(_token_ranks=dict([(k, v.tid) for k, v in token_ranks.items()]))
 
     def num_token_ranks(self):
         return len(self._token_ranks)
@@ -102,7 +102,7 @@ class Word(Token):
         self._token_ranks.clear()
 
     def add_token_ranks(self, key: int, value: "Word"):
-        self._token_ranks[key] = self.pack.add_entry_(value)
+        self._token_ranks[key] = value.tid
 
 
 class WordLink(Link):

--- a/tests/forte/data/ontology/test_outputs/ft/onto/ft_module.py
+++ b/tests/forte/data/ontology/test_outputs/ft/onto/ft_module.py
@@ -108,7 +108,7 @@ class Sentence(Annotation):
     @tokens.setter
     def tokens(self, tokens: Optional[List[Token]]):
         tokens = [] if tokens is None else tokens
-        self.set_fields(_tokens=[self.pack.add_entry_(obj) for obj in tokens])
+        self.set_fields(_tokens=[obj.tid for obj in tokens])
 
     def num_tokens(self):
         return len(self._tokens)
@@ -118,7 +118,7 @@ class Sentence(Annotation):
         self._tokens.clear()
 
     def add_tokens(self, a_tokens: Token):
-        self._tokens.append(self.pack.add_entry_(a_tokens))
+        self._tokens.append(a_tokens.tid)
 
 
 class Document(Annotation):

--- a/tests/forte/data/ontology/test_outputs/ft/onto/race_qa_installed_ontology.py
+++ b/tests/forte/data/ontology/test_outputs/ft/onto/race_qa_installed_ontology.py
@@ -88,7 +88,7 @@ class Question(Annotation):
     @options.setter
     def options(self, options: Optional[List[Option]]):
         options = [] if options is None else options
-        self.set_fields(_options=[self.pack.add_entry_(obj) for obj in options])
+        self.set_fields(_options=[obj.tid for obj in options])
 
     def num_options(self):
         return len(self._options)
@@ -98,7 +98,7 @@ class Question(Annotation):
         self._options.clear()
 
     def add_options(self, a_options: Option):
-        self._options.append(self.pack.add_entry_(a_options))
+        self._options.append(a_options.tid)
 
     @property
     def answers(self):

--- a/tests/forte/data/ontology/test_outputs/ft/onto/race_qa_ontology.py
+++ b/tests/forte/data/ontology/test_outputs/ft/onto/race_qa_ontology.py
@@ -88,7 +88,7 @@ class Question(Annotation):
     @options.setter
     def options(self, options: Optional[List[Option]]):
         options = [] if options is None else options
-        self.set_fields(_options=[self.pack.add_entry_(obj) for obj in options])
+        self.set_fields(_options=[obj.tid for obj in options])
 
     def num_options(self):
         return len(self._options)
@@ -98,7 +98,7 @@ class Question(Annotation):
         self._options.clear()
 
     def add_options(self, a_options: Option):
-        self._options.append(self.pack.add_entry_(a_options))
+        self._options.append(a_options.tid)
 
     @property
     def answers(self):

--- a/tests/forte/data/readers/conllu_ud_reader_test.py
+++ b/tests/forte/data/readers/conllu_ud_reader_test.py
@@ -20,6 +20,7 @@ import unittest
 
 from typing import List
 
+from forte.pipeline import Pipeline
 from ft.onto.base_ontology import Sentence, Document, Dependency
 from forte.data.readers import ConllUDReader
 from forte.data.data_pack import DataPack
@@ -34,9 +35,12 @@ class ConllUDReaderTest(unittest.TestCase):
         conll_ud_dir = os.path.abspath(os.path.join(file_dir_path,
                                                     *([os.pardir] * 4),
                                                     'data_samples/conll_ud'))
-        reader = ConllUDReader()
+        pl = Pipeline()
+        pl.set_reader(ConllUDReader())
+        pl.initialize()
+
         self.data_packs: List[DataPack] = \
-            [data_pack for data_pack in reader.iter(conll_ud_dir)]
+            [data_pack for data_pack in pl.process_dataset(conll_ud_dir)]
         self.doc_ids = ["weblog-blogspot.com_nominations_20041117172713_ENG_"
                         "20041117_172713",
                         "weblog-blogspot.com_nominations_20041117172713_ENG_"

--- a/tests/forte/data/readers/multipack_sentence_reader_test.py
+++ b/tests/forte/data/readers/multipack_sentence_reader_test.py
@@ -43,8 +43,11 @@ class MultiPackSentenceReaderTest(unittest.TestCase):
         with open(file_path, 'w') as f:
             f.write(text)
 
-        multipack = list(MultiPackSentenceReader().parse_pack(
-            (self.test_dir, file_path)))[0]
+        pl = Pipeline()
+        pl.set_reader(MultiPackSentenceReader())
+        pl.initialize()
+
+        multipack: MultiPack = pl.process_one(self.test_dir)
         input_pack = multipack.get_pack('input_src')
         self.assertEqual(len(multipack.packs), 2)
         self.assertEqual(multipack._pack_names, ['input_src', 'output_tgt'])

--- a/tests/forte/data/readers/plaintext_reader_test.py
+++ b/tests/forte/data/readers/plaintext_reader_test.py
@@ -22,6 +22,7 @@ from ddt import ddt, data
 
 from forte.data.span import Span
 from forte.data.readers import PlainTextReader
+from forte.pack_manager import PackManager
 
 
 @ddt
@@ -41,7 +42,9 @@ class PlainTextReaderTest(unittest.TestCase):
 
     def test_reader_no_replace_test(self):
         # Read with no replacements
-        pack = list(PlainTextReader().parse_pack(self.file_path))[0]
+        reader = PlainTextReader()
+        PackManager().set_input_source(reader.component_name)
+        pack = list(reader.parse_pack(self.file_path))[0]
         self.assertEqual(pack.text, self.orig_text)
 
     @data(
@@ -97,6 +100,7 @@ class PlainTextReaderTest(unittest.TestCase):
                             '<title>The New Shiny Title Ends </title>')
         input_span, expected_span, mode = value
         reader = PlainTextReader()
+        PackManager().set_input_source(reader.component_name)
         reader.text_replace_operation = lambda _: span_ops
         pack = list(reader.parse_pack(self.file_path))[0]
         self.assertEqual(pack.text, output)

--- a/tests/forte/data/readers/race_multi_choice_qa_reader_test.py
+++ b/tests/forte/data/readers/race_multi_choice_qa_reader_test.py
@@ -21,6 +21,7 @@ from typing import Iterator
 
 from forte.data.readers import RACEMultiChoiceQAReader
 from forte.data.data_pack import DataPack
+from forte.pack_manager import PackManager
 from ft.onto.race_multi_choice_qa_ontology import RaceDocument, Question
 
 
@@ -35,6 +36,8 @@ class RACEMultiChoiceQAReaderTest(unittest.TestCase):
     def test_reader_no_replace_test(self):
         # Read with no replacements
         reader = RACEMultiChoiceQAReader()
+        PackManager().set_input_source(reader.name)
+
         data_packs: Iterator[DataPack] = reader.iter(self.dataset_path)
         file_paths: Iterator[str] = reader._collect(self.dataset_path)
 

--- a/tests/forte/data/selector_test.py
+++ b/tests/forte/data/selector_test.py
@@ -16,7 +16,6 @@ Unit tests for Selector
 """
 import unittest
 
-from forte.data.data_pack import DataPack
 from forte.data.multi_pack import MultiPack
 from forte.data.selector import NameMatchSelector, RegexNameMatchSelector, \
     FirstPackSelector, AllPackSelector
@@ -25,13 +24,15 @@ from forte.data.selector import NameMatchSelector, RegexNameMatchSelector, \
 class SelectorTest(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.data_pack1 = DataPack(doc_id="1")
-        self.data_pack2 = DataPack(doc_id="2")
-        self.data_pack3 = DataPack(doc_id="Three")
         self.multi_pack = MultiPack()
-        self.multi_pack.add_pack(self.data_pack1, pack_name="pack1")
-        self.multi_pack.add_pack(self.data_pack2, pack_name="pack2")
-        self.multi_pack.add_pack(self.data_pack3, pack_name="pack_three")
+
+        data_pack1 = self.multi_pack.add_pack(pack_name="pack1")
+        data_pack2 = self.multi_pack.add_pack(pack_name="pack2")
+        data_pack3 = self.multi_pack.add_pack(pack_name="pack_three")
+
+        data_pack1.doc_id = "1"
+        data_pack2.doc_id = "2"
+        data_pack3.doc_id = "Three"
 
     def test_name_match_selector(self) -> None:
         selector = NameMatchSelector(select_name="pack1")

--- a/tests/forte/pipeline_test.py
+++ b/tests/forte/pipeline_test.py
@@ -65,10 +65,14 @@ class SentenceReader(PackReader):
                 line = line.strip()
                 if len(line) == 0:
                     continue
+
+                pack.set_text(line)
                 sent = Sentence(pack, 0, len(line))
                 pack.add_entry(sent)
-                pack.set_text(line)
                 self.count += 1
+
+                print('#### yielding data : ', line)
+
                 yield pack
 
 
@@ -288,6 +292,7 @@ class PipelineTest(unittest.TestCase):
     @unpack
     def test_pipeline5(self, batch_size1, batch_size2):
         # Tests a chain of Batch->Pack->Batch with different batch sizes.
+        print('running pipeline 5 with', batch_size1, batch_size2)
 
         nlp = Pipeline[DataPack]()
         reader = SentenceReader()
@@ -529,6 +534,7 @@ class MultiPackPipelineTest(unittest.TestCase):
 
         num_packs = 0
         for pack in nlp.process_dataset(data_path):
+            print(pack.pack_names)
             types = list(pack.get_pack("pack").get_entries_by_type(NewType))
             num_packs += 1
             self.assertEqual(len(types), 1)

--- a/tests/forte/pipeline_test.py
+++ b/tests/forte/pipeline_test.py
@@ -21,11 +21,12 @@ from typing import Any, Dict, Iterator, Optional, Type
 
 from ddt import ddt, data, unpack
 
+from forte.data.caster import MultiPackBoxer
 from forte.data.data_pack import DataPack
 from forte.data.multi_pack import MultiPack
 from forte.data.ontology.top import Generics
 from forte.data.readers.base_reader import PackReader, MultiPackReader
-from forte.data.selector import FirstPackSelector
+from forte.data.selector import FirstPackSelector, NameMatchSelector
 from forte.pipeline import Pipeline
 from forte.processors.base import PackProcessor, FixedSizeBatchProcessor
 from ft.onto.base_ontology import Token, Sentence
@@ -67,11 +68,8 @@ class SentenceReader(PackReader):
                     continue
 
                 pack.set_text(line)
-                sent = Sentence(pack, 0, len(line))
-                pack.add_entry(sent)
+                Sentence(pack, 0, len(line))
                 self.count += 1
-
-                print('#### yielding data : ', line)
 
                 yield pack
 
@@ -103,9 +101,7 @@ class MultiPackSentenceReader(MultiPackReader):
                 pack = m_pack.add_pack('pack')
                 pack.set_text(line)
 
-                sent = Sentence(pack, 0, len(line))
-                pack.add_entry(sent)
-
+                Sentence(pack, 0, len(line))
                 self.count += 1
 
                 yield m_pack  # type: ignore
@@ -119,8 +115,7 @@ class DummyPackProcessor(PackProcessor):
     def _process(self, input_pack: DataPack):
         entries = list(input_pack.get_entries_by_type(NewType))
         if len(entries) == 0:
-            entry = NewType(pack=input_pack, value="[PACK]")
-            input_pack.add_entry(entry)
+            NewType(pack=input_pack, value="[PACK]")
         else:
             entry = entries[0]  # type: ignore
             entry.value += "[PACK]"
@@ -147,7 +142,6 @@ class DummmyFixedSizeBatchProcessor(FixedSizeBatchProcessor):
         entries = list(data_pack.get_entries_by_type(NewType))
         if len(entries) == 0:
             entry = NewType(pack=data_pack, value="[BATCH]")
-            data_pack.add_entry(entry)
         else:
             entry = entries[0]  # type: ignore
             entry.value += "[BATCH]"
@@ -292,8 +286,6 @@ class PipelineTest(unittest.TestCase):
     @unpack
     def test_pipeline5(self, batch_size1, batch_size2):
         # Tests a chain of Batch->Pack->Batch with different batch sizes.
-        print('running pipeline 5 with', batch_size1, batch_size2)
-
         nlp = Pipeline[DataPack]()
         reader = SentenceReader()
         nlp.set_reader(reader)
@@ -384,21 +376,29 @@ class PipelineTest(unittest.TestCase):
 @ddt
 class MultiPackPipelineTest(unittest.TestCase):
 
-    def test_process_next(self):
+    #  TODO: This is not a multi pack test.
+    def test_process_multi_next(self):
         from forte.data.readers import OntonotesReader
 
         # Define and config the Pipeline
         nlp = Pipeline[DataPack]()
         nlp.set_reader(OntonotesReader())
-        dummy = DummyRelationExtractor()
-        config = {"batcher": {"batch_size": 5}}
-        nlp.add(dummy, config=config)
+
+        pack_name = 'test_pack'
+        nlp.add(MultiPackBoxer(), {'pack_name': pack_name})
+        nlp.add(
+            DummyRelationExtractor(),
+            config={"batcher": {"batch_size": 5}},
+            selector=NameMatchSelector(select_name=pack_name)
+        )
         nlp.initialize()
 
         dataset_path = data_samples_root + "/ontonotes/00"
 
         # get processed pack from dataset
-        for pack in nlp.process_dataset(dataset_path):
+        m_pack: MultiPack
+        for m_pack in nlp.process_dataset(dataset_path):
+            pack = m_pack.get_pack(pack_name)
             # get sentence from pack
             for sentence in pack.get_entries(Sentence):
                 sent_text = sentence.text
@@ -534,7 +534,6 @@ class MultiPackPipelineTest(unittest.TestCase):
 
         num_packs = 0
         for pack in nlp.process_dataset(data_path):
-            print(pack.pack_names)
             types = list(pack.get_pack("pack").get_entries_by_type(NewType))
             num_packs += 1
             self.assertEqual(len(types), 1)

--- a/tests/forte/pipeline_test.py
+++ b/tests/forte/pipeline_test.py
@@ -91,16 +91,19 @@ class MultiPackSentenceReader(MultiPackReader):
     def _parse_pack(self, file_path: str) -> Iterator[DataPack]:  # type: ignore
         with open(file_path, "r", encoding="utf8") as doc:
             for line in doc:
-                m_pack = MultiPack()
-                pack = DataPack(doc_id=file_path)
                 line = line.strip()
                 if len(line) == 0:
                     continue
+
+                m_pack = MultiPack()
+                pack = m_pack.add_pack('pack')
+                pack.set_text(line)
+
                 sent = Sentence(pack, 0, len(line))
                 pack.add_entry(sent)
-                pack.set_text(line)
+
                 self.count += 1
-                m_pack.update_pack({"pack": pack})
+
                 yield m_pack  # type: ignore
 
 

--- a/tests/forte/processors/nltk_processors_test.py
+++ b/tests/forte/processors/nltk_processors_test.py
@@ -58,9 +58,9 @@ class TestNLTKWordTokenizer(unittest.TestCase):
                      "The goal of this project to help you build NLP "
                      "pipelines.",
                      "NLP has never been made this easy before."]
-        tokens = [["This", "tool", "is", "called", "Forte", "."],
+        tokens = [["This", "tool", "is", "called", "Forte."],
                   ["The", "goal", "of", "this", "project", "to", "help", "you",
-                   "build", "NLP", "pipelines", "."],
+                   "build", "NLP", "pipelines."],
                   ["NLP", "has", "never", "been", "made", "this", "easy",
                    "before", "."]]
         document = ' '.join(sentences)
@@ -86,9 +86,9 @@ class TestNLTKPOSTagger(unittest.TestCase):
                      "The goal of this project to help you build NLP "
                      "pipelines.",
                      "NLP has never been made this easy before."]
-        pos = [["DT", "NN", "VBZ", "VBN", "NNP", "."],
+        pos = [["DT", "NN", "VBZ", "VBN", "NNP"],
                ["DT", "NN", "IN", "DT", "NN", "TO", "VB", "PRP", "VB", "NNP",
-                "NNS", "."],
+                "NN"],
                ["NNP", "VBZ", "RB", "VBN", "VBN", "DT", "JJ", "RB", "."]]
         document = ' '.join(sentences)
         pack = self.nltk.process(document)
@@ -114,9 +114,9 @@ class TestNLTKLemmatizer(unittest.TestCase):
                      "The goal of this project to help you build NLP "
                      "pipelines.",
                      "NLP has never been made this easy before."]
-        tokens = [["This", "tool", "be", "call", "Forte", "."],
+        tokens = [["This", "tool", "be", "call", "Forte."],
                   ["The", "goal", "of", "this", "project", "to", "help", "you",
-                   "build", "NLP", "pipeline", "."],
+                   "build", "NLP", "pipelines."],
                   ["NLP", "have", "never", "be", "make", "this", "easy",
                    "before", "."]]
         document = ' '.join(sentences)
@@ -153,8 +153,8 @@ class TestNLTKChunker(unittest.TestCase):
         entities_type = [x.phrase_type for x in phrase_entries]
 
         self.assertEqual(entities_text, ['This tool', 'The goal',
-                                         'this project'])
-        self.assertEqual(entities_type, ['NP', 'NP', 'NP'])
+                                         'this project', 'pipelines.'])
+        self.assertEqual(entities_type, ['NP', 'NP', 'NP', 'NP'])
 
 
 class TestNLTKNER(unittest.TestCase):
@@ -169,7 +169,7 @@ class TestNLTKNER(unittest.TestCase):
         self.nltk.initialize()
 
     def test_ner(self):
-        sentences = ["This tool is called New   York.",
+        sentences = ["This tool is called New York .",
                      "The goal of this project to help you build NLP "
                      "pipelines.",
                      "NLP has never been made this easy before."]
@@ -181,7 +181,7 @@ class TestNLTKNER(unittest.TestCase):
         entities_text = [x.text for x in entities_entries]
         entities_type = [x.ner_type for x in entities_entries]
 
-        self.assertEqual(entities_text, ['New   York', 'NLP', 'NLP'])
+        self.assertEqual(entities_text, ['New York', 'NLP', 'NLP'])
         self.assertEqual(entities_type, ['GPE', 'ORGANIZATION', 'ORGANIZATION'])
 
 


### PR DESCRIPTION
This PR allows the entries to be added to the packs without manually calling `add_pack`. Further, `add_or_get_pack` is removed. 