### PR TITLE
Write URIs in multi pack serialization instead of paths.

### DIFF
--- a/forte/processors/base/writers.py
+++ b/forte/processors/base/writers.py
@@ -19,6 +19,7 @@ import gzip
 import json
 import logging
 import os
+import posixpath
 from abc import abstractmethod, ABC
 from typing import Optional, Any, Dict
 
@@ -181,7 +182,7 @@ class MultiPackWriter(MultiPackProcessor):
 
             self.pack_idx_out.write(
                 f'{pack.meta.pack_id}\t'
-                f'{os.path.relpath(pack_out, self.configs.output_dir)}\n')
+                f'{posixpath.relpath(pack_out, self.configs.output_dir)}\n')
 
         multi_out = write_pack(
             input_pack, multi_out_dir,
@@ -192,7 +193,7 @@ class MultiPackWriter(MultiPackProcessor):
 
         self.multi_idx_out.write(
             f'{input_pack.meta.pack_id}\t'
-            f'{os.path.relpath(multi_out, self.configs.output_dir)}\n')
+            f'{posixpath.relpath(multi_out, self.configs.output_dir)}\n')
 
     def finish(self, _):
         self.pack_idx_out.close()


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/202. 

### Description of changes
Use posixpath instead of os.path for URI pattern.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Adding slash checks in `https://github.com/asyml/forte/blob/master/tests/examples/serialization/test_serialization_example.py`