### PR TITLE
Add instructions to examples so they can be shown on webpages.

### DIFF
--- a/examples/content_rewriter/table_inputs/table_Cocum.json
+++ b/examples/content_rewriter/table_inputs/table_Cocum.json
@@ -1,13 +1,7 @@
 {
   "py/object": "forte.data.data_pack.DataPack",
   "py/state": {
-    "creation_records": {
-      "examples.content_rewriter.reader.TableReader": {
-        "py/set": [
-          0
-        ]
-      }
-    },
+    "creation_records": {},
     "field_records": {},
     "links": [],
     "groups": [],
@@ -20,7 +14,7 @@
         "span_unit": "character"
       }
     },
-    "_text": "Cocum|name|Cocum coffee_shop|eatType|Cocum Japanese|food|Cocum less_than_\u00a320|priceRange|Cocum riverside|area|Cocum family_friendly|family-friendly|Cocum Raja_Indian_Cuisine|near|Cocum",
+    "_text": "Cocum|name|Cocum coffee_shop|eatType|Cocum Japanese|food|Cocum less_than_\u00a320|priceRange|Cocum riverside|area|Cocum family_friendly|family-friendly|Cocum Raja_Indian_Cuisine|near|Cocum\nThis is an example to use the chatbot interface with the content rewriter model. To run this example, follow the instructions here \"https://github.com/asyml/forte/tree/master/examples/content_rewriter\" to obtain the models and make sure Forte is in your Python Path.",
     "annotations": [
       {
         "py/object": "ft.onto.base_ontology.UtteranceContext",
@@ -32,14 +26,26 @@
           },
           "_tid": 0
         }
+      },
+      {
+        "py/object": "ft.onto.base_ontology.Utterance",
+        "py/state": {
+          "_span": {
+            "py/object": "forte.data.span.Span",
+            "begin": 184,
+            "end": 450
+          },
+          "_tid": 1,
+          "speaker": "ai"
+        }
       }
     ],
     "generics": [],
     "replace_back_operations": [],
     "processed_original_spans": [],
-    "orig_text_len": 183,
+    "orig_text_len": 450,
     "serialization": {
-      "next_id": 1
+      "next_id": 2
     }
   }
 }

--- a/examples/content_rewriter/table_inputs/table_Loch_Fyne.json
+++ b/examples/content_rewriter/table_inputs/table_Loch_Fyne.json
@@ -1,13 +1,7 @@
 {
   "py/object": "forte.data.data_pack.DataPack",
   "py/state": {
-    "creation_records": {
-      "examples.content_rewriter.reader.TableReader": {
-        "py/set": [
-          0
-        ]
-      }
-    },
+    "creation_records": {},
     "field_records": {},
     "links": [],
     "groups": [],
@@ -20,7 +14,7 @@
         "span_unit": "character"
       }
     },
-    "_text": "Loch_Fyne|name|Loch_Fyne coffee_shop|eatType|Loch_Fyne fast|food|Loch_Fyne cheap|priceRange|Loch_Fyne 5_out_of_5|customerRating|Loch_Fyne riverside|area|Loch_Fyne",
+    "_text": "Loch_Fyne|name|Loch_Fyne coffee_shop|eatType|Loch_Fyne fast|food|Loch_Fyne cheap|priceRange|Loch_Fyne 5_out_of_5|customerRating|Loch_Fyne riverside|area|Loch_Fyne\nThis is an example to use the chatbot interface with the content rewriter model. To run this example, follow the instructions here \"https://github.com/asyml/forte/tree/master/examples/content_rewriter\" to obtain the models and make sure Forte is in your Python Path.",
     "annotations": [
       {
         "py/object": "ft.onto.base_ontology.UtteranceContext",
@@ -32,14 +26,26 @@
           },
           "_tid": 0
         }
+      },
+      {
+        "py/object": "ft.onto.base_ontology.Utterance",
+        "py/state": {
+          "_span": {
+            "py/object": "forte.data.span.Span",
+            "begin": 163,
+            "end": 429
+          },
+          "_tid": 1,
+          "speaker": "ai"
+        }
       }
     ],
     "generics": [],
     "replace_back_operations": [],
     "processed_original_spans": [],
-    "orig_text_len": 162,
+    "orig_text_len": 429,
     "serialization": {
-      "next_id": 1
+      "next_id": 2
     }
   }
 }

--- a/examples/content_rewriter/table_inputs/table_The_Mill.json
+++ b/examples/content_rewriter/table_inputs/table_The_Mill.json
@@ -1,13 +1,7 @@
 {
   "py/object": "forte.data.data_pack.DataPack",
   "py/state": {
-    "creation_records": {
-      "examples.content_rewriter.reader.TableReader": {
-        "py/set": [
-          0
-        ]
-      }
-    },
+    "creation_records": {},
     "field_records": {},
     "links": [],
     "groups": [],
@@ -20,7 +14,7 @@
         "span_unit": "character"
       }
     },
-    "_text": "The_Mill|name|The_Mill pub|eatType|The_Mill French|food|The_Mill \u00a320-25|priceRange|The_Mill riverside|area|The_Mill The_Sorrento|near|The_Mill",
+    "_text": "The_Mill|name|The_Mill pub|eatType|The_Mill French|food|The_Mill \u00a320-25|priceRange|The_Mill riverside|area|The_Mill The_Sorrento|near|The_Mill\nThis is an example to use the chatbot interface with the content rewriter model. To run this example, follow the instructions here \"https://github.com/asyml/forte/tree/master/examples/content_rewriter\" to obtain the models and make sure Forte is in your Python Path.",
     "annotations": [
       {
         "py/object": "ft.onto.base_ontology.UtteranceContext",
@@ -32,14 +26,26 @@
           },
           "_tid": 0
         }
+      },
+      {
+        "py/object": "ft.onto.base_ontology.Utterance",
+        "py/state": {
+          "_span": {
+            "py/object": "forte.data.span.Span",
+            "begin": 143,
+            "end": 409
+          },
+          "_tid": 1,
+          "speaker": "ai"
+        }
       }
     ],
     "generics": [],
     "replace_back_operations": [],
     "processed_original_spans": [],
-    "orig_text_len": 142,
+    "orig_text_len": 409,
     "serialization": {
-      "next_id": 1
+      "next_id": 2
     }
   }
 }

--- a/examples/content_rewriter/table_inputs/table_The_Vaults.json
+++ b/examples/content_rewriter/table_inputs/table_The_Vaults.json
@@ -1,13 +1,7 @@
 {
   "py/object": "forte.data.data_pack.DataPack",
   "py/state": {
-    "creation_records": {
-      "examples.content_rewriter.reader.TableReader": {
-        "py/set": [
-          0
-        ]
-      }
-    },
+    "creation_records": {},
     "field_records": {},
     "links": [],
     "groups": [],
@@ -20,7 +14,7 @@
         "span_unit": "character"
       }
     },
-    "_text": "The_Vaults|name|The_Vaults pub|eatType|The_Vaults more_than_\u00a330|priceRange|The_Vaults 5_out_of_5|customerRating|The_Vaults Caf\u00e9_Adriatic|near|The_Vaults,",
+    "_text": "The_Vaults|name|The_Vaults pub|eatType|The_Vaults more_than_\u00a330|priceRange|The_Vaults 5_out_of_5|customerRating|The_Vaults Caf\u00e9_Adriatic|near|The_Vaults,\nThis is an example to use the chatbot interface with the content rewriter model. To run this example, follow the instructions here \"https://github.com/asyml/forte/tree/master/examples/content_rewriter\" to obtain the models and make sure Forte is in your Python Path.",
     "annotations": [
       {
         "py/object": "ft.onto.base_ontology.UtteranceContext",
@@ -32,14 +26,26 @@
           },
           "_tid": 0
         }
+      },
+      {
+        "py/object": "ft.onto.base_ontology.Utterance",
+        "py/state": {
+          "_span": {
+            "py/object": "forte.data.span.Span",
+            "begin": 154,
+            "end": 420
+          },
+          "_tid": 1,
+          "speaker": "ai"
+        }
       }
     ],
     "generics": [],
     "replace_back_operations": [],
     "processed_original_spans": [],
-    "orig_text_len": 153,
+    "orig_text_len": 420,
     "serialization": {
-      "next_id": 1
+      "next_id": 2
     }
   }
 }


### PR DESCRIPTION
This PR adds some instruction into the content rewriter data.

### Description of changes
The content rewriter datapack only contains the table, which is not clear to the users what to do. I added the instruction there.

### Possible influences of this PR.
N/A

### Test Conducted
This example is currently not tested.