### PR TITLE
Fix the problem of self referencing during code generation.

### DIFF
--- a/forte/data/ontology/code_generation_objects.py
+++ b/forte/data/ontology/code_generation_objects.py
@@ -319,7 +319,7 @@ class ClassTypeDefinition:
 class NonCompositeProperty(Property):
     def __init__(self, import_manager: ImportManager,
                  name: str, type_str: str, description: Optional[str] = None,
-                 default_val: Any = None):
+                 default_val: Any = None, self_ref: bool = False):
         super(NonCompositeProperty, self).__init__(
             import_manager, name, type_str, description, default_val)
 
@@ -329,10 +329,13 @@ class NonCompositeProperty(Property):
         import_manager.add_object_to_import(self.option_type)
 
         self.is_forte_type = import_manager.is_imported(type_str)
+        self.self_ref = self_ref
 
     def internal_type_str(self) -> str:
         option_type = self.import_manager.get_name_to_use(self.option_type)
         type_str = self.import_manager.get_name_to_use(self.type_str)
+        if self.self_ref:
+            type_str = f"'{type_str}'"
         return f"{option_type}[{type_str}]"
 
     def default_value(self) -> str:
@@ -375,7 +378,7 @@ class DictProperty(Property):
         key_type = self.import_manager.get_name_to_use(self.key_type)
         value_type = self.import_manager.get_name_to_use(self.value_type)
         if self.self_ref:
-            value_type = '"' + value_type + '"'
+            value_type = f"'{value_type}'"
 
         return f"{composite_type}[{key_type}, {value_type}]"
 
@@ -398,8 +401,6 @@ class ListProperty(Property):
                          description=description,
                          default_val=default_val)
         self.item_type: str = item_type
-        # self_ref would probably not happen, because we are using int for
-        # entry types.
         self.self_ref: bool = self_ref
 
     def internal_type_str(self) -> str:
@@ -415,6 +416,9 @@ class ListProperty(Property):
     def _full_class(self):
         composite_type = self.import_manager.get_name_to_use(self.type_str)
         item_type = self.import_manager.get_name_to_use(self.item_type)
+        if self.self_ref:
+            item_type = f"'{item_type}'"
+
         return f"{composite_type}[{item_type}]"
 
     def to_field_value(self):

--- a/forte/ontology_specs/base_ontology.json
+++ b/forte/ontology_specs/base_ontology.json
@@ -270,6 +270,40 @@
       ],
       "parent_type": "ft.onto.base_ontology.EventMention",
       "child_type": "ft.onto.base_ontology.EventMention"
+    },
+    {
+     "entry_name": "ft.onto.base_ontology.ConstituentNode",
+     "parent_entry": "forte.data.ontology.top.Annotation",
+     "description": "A span based annotation `ConstituentNode` to represent constituents in constituency parsing. This can also sentiment values annotated on the nodes.",
+     "attributes": [
+       {
+         "name": "label",
+         "type": "str"
+       },
+       {
+         "name": "sentiment",
+         "type": "Dict",
+         "key_type": "str",
+         "value_type": "float"
+       },
+       {
+         "name": "is_root",
+         "type": "bool"
+       },
+       {
+         "name": "is_leaf",
+         "type": "bool"
+       },
+       {
+         "name": "parent_node",
+         "type": "ft.onto.base_ontology.ConstituentNode"
+       },
+       {
+         "name": "children_nodes",
+         "type": "List",
+         "item_type": "ft.onto.base_ontology.ConstituentNode"
+       }
+     ]
     }
   ]
 }

--- a/ft/onto/base_ontology.py
+++ b/ft/onto/base_ontology.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from forte.data.data_pack import DataPack
 from forte.data.multi_pack import MultiPack
 from forte.data.ontology.core import Entry
+from forte.data.ontology.core import FList
 from forte.data.ontology.top import Annotation
 from forte.data.ontology.top import Group
 from forte.data.ontology.top import Link
@@ -38,6 +39,7 @@ __all__ = [
     "CoreferenceGroup",
     "EventRelation",
     "CrossDocEventRelation",
+    "ConstituentNode",
 ]
 
 
@@ -361,3 +363,33 @@ class CrossDocEventRelation(MultiPackLink):
     def __init__(self, pack: MultiPack, parent: Optional[Entry] = None, child: Optional[Entry] = None):
         super().__init__(pack, parent, child)
         self.rel_type: Optional[str] = None
+
+
+@dataclass
+class ConstituentNode(Annotation):
+    """
+    A span based annotation `ConstituentNode` to represent constituents in constituency parsing. This can also sentiment values annotated on the nodes.
+    Attributes:
+        label (Optional[str])
+        sentiment (Dict[str, float])
+        is_root (Optional[bool])
+        is_leaf (Optional[bool])
+        parent_node (Optional['ConstituentNode'])
+        children_nodes (FList['ConstituentNode'])
+    """
+
+    label: Optional[str]
+    sentiment: Dict[str, float]
+    is_root: Optional[bool]
+    is_leaf: Optional[bool]
+    parent_node: Optional['ConstituentNode']
+    children_nodes: FList['ConstituentNode']
+
+    def __init__(self, pack: DataPack, begin: int, end: int):
+        super().__init__(pack, begin, end)
+        self.label: Optional[str] = None
+        self.sentiment: Dict[str, float] = dict()
+        self.is_root: Optional[bool] = None
+        self.is_leaf: Optional[bool] = None
+        self.parent_node: Optional['ConstituentNode'] = None
+        self.children_nodes: FList['ConstituentNode'] = FList(self)

--- a/tests/forte/data/ontology/test_outputs/ft/onto/base_ontology.py
+++ b/tests/forte/data/ontology/test_outputs/ft/onto/base_ontology.py
@@ -1,5 +1,5 @@
 # ***automatically_generated***
-# ***source json:tests/forte/data/ontology/test_specs/base_ontology.json***
+# ***source json:forte/ontology_specs/base_ontology.json***
 # flake8: noqa
 # mypy: ignore-errors
 # pylint: skip-file
@@ -9,10 +9,13 @@ Automatically generated ontology base_ontology. Do not change manually.
 
 from dataclasses import dataclass
 from forte.data.data_pack import DataPack
+from forte.data.multi_pack import MultiPack
 from forte.data.ontology.core import Entry
+from forte.data.ontology.core import FList
 from forte.data.ontology.top import Annotation
 from forte.data.ontology.top import Group
 from forte.data.ontology.top import Link
+from forte.data.ontology.top import MultiPackLink
 from typing import Dict
 from typing import Optional
 from typing import Set
@@ -20,18 +23,23 @@ from typing import Set
 __all__ = [
     "Token",
     "Document",
-    "SpecialDocument",
     "Sentence",
     "Phrase",
+    "UtteranceContext",
     "Utterance",
     "PredicateArgument",
     "EntityMention",
+    "EventMention",
     "PredicateMention",
     "PredicateLink",
     "Dependency",
     "EnhancedDependency",
     "RelationLink",
+    "CrossDocEntityRelation",
     "CoreferenceGroup",
+    "EventRelation",
+    "CrossDocEventRelation",
+    "ConstituentNode",
 ]
 
 
@@ -85,28 +93,24 @@ class Document(Annotation):
 
 
 @dataclass
-class SpecialDocument(Document):
-
-    def __init__(self, pack: DataPack, begin: int, end: int):
-        super().__init__(pack, begin, end)
-
-
-@dataclass
 class Sentence(Annotation):
     """
     A span based annotation `Sentence`, normally used to represent a sentence.
     Attributes:
         speaker (Optional[str])
         part_id (Optional[int])
+        sentiment (Dict[str, float])
     """
 
     speaker: Optional[str]
     part_id: Optional[int]
+    sentiment: Dict[str, float]
 
     def __init__(self, pack: DataPack, begin: int, end: int):
         super().__init__(pack, begin, end)
         self.speaker: Optional[str] = None
         self.part_id: Optional[int] = None
+        self.sentiment: Dict[str, float] = dict()
 
 
 @dataclass
@@ -125,13 +129,28 @@ class Phrase(Annotation):
 
 
 @dataclass
-class Utterance(Annotation):
+class UtteranceContext(Annotation):
     """
-    A span based annotation `Utterance`, normally used to represent an utterance in dialogue.
+    `UtteranceContext` represents the context part in dialogue.
     """
 
     def __init__(self, pack: DataPack, begin: int, end: int):
         super().__init__(pack, begin, end)
+
+
+@dataclass
+class Utterance(Annotation):
+    """
+    A span based annotation `Utterance`, normally used to represent an utterance in dialogue.
+    Attributes:
+        speaker (Optional[str])
+    """
+
+    speaker: Optional[str]
+
+    def __init__(self, pack: DataPack, begin: int, end: int):
+        super().__init__(pack, begin, end)
+        self.speaker: Optional[str] = None
 
 
 @dataclass
@@ -168,6 +187,21 @@ class EntityMention(Annotation):
     def __init__(self, pack: DataPack, begin: int, end: int):
         super().__init__(pack, begin, end)
         self.ner_type: Optional[str] = None
+
+
+@dataclass
+class EventMention(Annotation):
+    """
+    A span based annotation `EventMention`, used to refer to a mention of an event.
+    Attributes:
+        event_type (Optional[str])
+    """
+
+    event_type: Optional[str]
+
+    def __init__(self, pack: DataPack, begin: int, end: int):
+        super().__init__(pack, begin, end)
+        self.event_type: Optional[str] = None
 
 
 @dataclass
@@ -252,7 +286,7 @@ class EnhancedDependency(Link):
 @dataclass
 class RelationLink(Link):
     """
-    A `Link` type entry which represent a relation.
+    A `Link` type entry which represent a relation between two entity mentions
     Attributes:
         rel_type (Optional[str])	The type of the relation.
     """
@@ -268,6 +302,24 @@ class RelationLink(Link):
 
 
 @dataclass
+class CrossDocEntityRelation(MultiPackLink):
+    """
+    A `Link` type entry which represent a relation between two entity mentions across the packs.
+    Attributes:
+        rel_type (Optional[str])	The type of the relation.
+    """
+
+    rel_type: Optional[str]
+
+    ParentType = EntityMention
+    ChildType = EntityMention
+
+    def __init__(self, pack: MultiPack, parent: Optional[Entry] = None, child: Optional[Entry] = None):
+        super().__init__(pack, parent, child)
+        self.rel_type: Optional[str] = None
+
+
+@dataclass
 class CoreferenceGroup(Group):
     """
     A group type entry that take `EntityMention`, as members, used to represent coreferent group of entities.
@@ -275,3 +327,69 @@ class CoreferenceGroup(Group):
 
     def __init__(self, pack: DataPack, members: Optional[Set[Entry]] = None):
         super().__init__(pack, members)
+
+
+@dataclass
+class EventRelation(Link):
+    """
+    A `Link` type entry which represent a relation between two event mentions.
+    Attributes:
+        rel_type (Optional[str])	The type of the relation.
+    """
+
+    rel_type: Optional[str]
+
+    ParentType = EventMention
+    ChildType = EventMention
+
+    def __init__(self, pack: DataPack, parent: Optional[Entry] = None, child: Optional[Entry] = None):
+        super().__init__(pack, parent, child)
+        self.rel_type: Optional[str] = None
+
+
+@dataclass
+class CrossDocEventRelation(MultiPackLink):
+    """
+    A `Link` type entry which represent a relation between two event mentions across the packs.
+    Attributes:
+        rel_type (Optional[str])	The type of the relation.
+    """
+
+    rel_type: Optional[str]
+
+    ParentType = EventMention
+    ChildType = EventMention
+
+    def __init__(self, pack: MultiPack, parent: Optional[Entry] = None, child: Optional[Entry] = None):
+        super().__init__(pack, parent, child)
+        self.rel_type: Optional[str] = None
+
+
+@dataclass
+class ConstituentNode(Annotation):
+    """
+    A span based annotation `ConstituentNode` to represent constituents in constituency parsing. This can also sentiment values annotated on the nodes.
+    Attributes:
+        label (Optional[str])
+        sentiment (Dict[str, float])
+        is_root (Optional[bool])
+        is_leaf (Optional[bool])
+        parent_node (Optional['ConstituentNode'])
+        children_nodes (FList['ConstituentNode'])
+    """
+
+    label: Optional[str]
+    sentiment: Dict[str, float]
+    is_root: Optional[bool]
+    is_leaf: Optional[bool]
+    parent_node: Optional['ConstituentNode']
+    children_nodes: FList['ConstituentNode']
+
+    def __init__(self, pack: DataPack, begin: int, end: int):
+        super().__init__(pack, begin, end)
+        self.label: Optional[str] = None
+        self.sentiment: Dict[str, float] = dict()
+        self.is_root: Optional[bool] = None
+        self.is_leaf: Optional[bool] = None
+        self.parent_node: Optional['ConstituentNode'] = None
+        self.children_nodes: FList['ConstituentNode'] = FList(self)

--- a/tests/forte/data/ontology/test_outputs/ft/onto/example_ontology.py
+++ b/tests/forte/data/ontology/test_outputs/ft/onto/example_ontology.py
@@ -28,19 +28,19 @@ class Word(Token):
     """
     Attributes:
         string_features (List[str])	To demonstrate the composite type, List.
-        word_forms (FList[Word])	To demonstrate that an attribute can be a List of other entries.
-        token_ranks (FDict[int, "Word"])	To demonstrate that an attribute can be a Dict, and the values can be other entries.
+        word_forms (FList['Word'])	To demonstrate that an attribute can be a List of other entries.
+        token_ranks (FDict[int, 'Word'])	To demonstrate that an attribute can be a Dict, and the values can be other entries.
     """
 
     string_features: List[str]
-    word_forms: FList[Word]
-    token_ranks: FDict[int, "Word"]
+    word_forms: FList['Word']
+    token_ranks: FDict[int, 'Word']
 
     def __init__(self, pack: DataPack, begin: int, end: int):
         super().__init__(pack, begin, end)
         self.string_features: List[str] = []
-        self.word_forms: FList[Word] = FList(self)
-        self.token_ranks: FDict[int, "Word"] = FDict(self)
+        self.word_forms: FList['Word'] = FList(self)
+        self.token_ranks: FDict[int, 'Word'] = FDict(self)
 
 
 @dataclass

--- a/tests/forte/data/ontology/test_specs/base_ontology.json
+++ b/tests/forte/data/ontology/test_specs/base_ontology.json
@@ -56,10 +56,6 @@
       "description": "A span based annotation `Document`, normally used to represent a document."
     },
     {
-      "entry_name": "ft.onto.base_ontology.SpecialDocument",
-      "parent_entry": "ft.onto.base_ontology.Document"
-    },
-    {
       "entry_name": "ft.onto.base_ontology.Sentence",
       "parent_entry": "forte.data.ontology.top.Annotation",
       "description": "A span based annotation `Sentence`, normally used to represent a sentence.",
@@ -71,6 +67,12 @@
         {
           "name": "part_id",
           "type": "int"
+        },
+        {
+          "name": "sentiment",
+          "type": "Dict",
+          "key_type": "str",
+          "value_type": "float"
         }
       ]
     },
@@ -86,9 +88,20 @@
       ]
     },
     {
+      "entry_name": "ft.onto.base_ontology.UtteranceContext",
+      "parent_entry": "forte.data.ontology.top.Annotation",
+      "description": "`UtteranceContext` represents the context part in dialogue."
+    },
+    {
       "entry_name": "ft.onto.base_ontology.Utterance",
       "parent_entry": "forte.data.ontology.top.Annotation",
-      "description": "A span based annotation `Utterance`, normally used to represent an utterance in dialogue."
+      "description": "A span based annotation `Utterance`, normally used to represent an utterance in dialogue.",
+      "attributes" : [
+        {
+          "name": "speaker",
+          "type": "str"
+        }
+      ]
     },
     {
       "entry_name": "ft.onto.base_ontology.PredicateArgument",
@@ -116,6 +129,17 @@
       "attributes": [
         {
           "name": "ner_type",
+          "type": "str"
+        }
+      ]
+    },
+    {
+      "entry_name": "ft.onto.base_ontology.EventMention",
+      "parent_entry": "forte.data.ontology.top.Annotation",
+      "description": "A span based annotation `EventMention`, used to refer to a mention of an event.",
+      "attributes": [
+        {
+          "name": "event_type",
           "type": "str"
         }
       ]
@@ -188,7 +212,21 @@
     {
       "entry_name": "ft.onto.base_ontology.RelationLink",
       "parent_entry": "forte.data.ontology.top.Link",
-      "description": "A `Link` type entry which represent a relation.",
+      "description": "A `Link` type entry which represent a relation between two entity mentions",
+      "attributes": [
+        {
+          "name": "rel_type",
+          "type": "str",
+          "description": "The type of the relation."
+        }
+      ],
+      "parent_type": "ft.onto.base_ontology.EntityMention",
+      "child_type": "ft.onto.base_ontology.EntityMention"
+    },
+    {
+      "entry_name": "ft.onto.base_ontology.CrossDocEntityRelation",
+      "parent_entry": "forte.data.ontology.top.MultiPackLink",
+      "description": "A `Link` type entry which represent a relation between two entity mentions across the packs.",
       "attributes": [
         {
           "name": "rel_type",
@@ -204,6 +242,68 @@
       "parent_entry": "forte.data.ontology.top.Group",
       "description": "A group type entry that take `EntityMention`, as members, used to represent coreferent group of entities.",
       "member_type": "ft.onto.base_ontology.EntityMention"
+    },
+    {
+      "entry_name": "ft.onto.base_ontology.EventRelation",
+      "parent_entry": "forte.data.ontology.top.Link",
+      "description": "A `Link` type entry which represent a relation between two event mentions.",
+      "attributes": [
+        {
+          "name": "rel_type",
+          "type": "str",
+          "description": "The type of the relation."
+        }
+      ],
+      "parent_type": "ft.onto.base_ontology.EventMention",
+      "child_type": "ft.onto.base_ontology.EventMention"
+    },
+    {
+      "entry_name": "ft.onto.base_ontology.CrossDocEventRelation",
+      "parent_entry": "forte.data.ontology.top.MultiPackLink",
+      "description": "A `Link` type entry which represent a relation between two event mentions across the packs.",
+      "attributes": [
+        {
+          "name": "rel_type",
+          "type": "str",
+          "description": "The type of the relation."
+        }
+      ],
+      "parent_type": "ft.onto.base_ontology.EventMention",
+      "child_type": "ft.onto.base_ontology.EventMention"
+    },
+    {
+     "entry_name": "ft.onto.base_ontology.ConstituentNode",
+     "parent_entry": "forte.data.ontology.top.Annotation",
+     "description": "A span based annotation `ConstituentNode` to represent constituents in constituency parsing. This can also sentiment values annotated on the nodes.",
+     "attributes": [
+       {
+         "name": "label",
+         "type": "str"
+       },
+       {
+         "name": "sentiment",
+         "type": "Dict",
+         "key_type": "str",
+         "value_type": "float"
+       },
+       {
+         "name": "is_root",
+         "type": "bool"
+       },
+       {
+         "name": "is_leaf",
+         "type": "bool"
+       },
+       {
+         "name": "parent_node",
+         "type": "ft.onto.base_ontology.ConstituentNode"
+       },
+       {
+         "name": "children_nodes",
+         "type": "List",
+         "item_type": "ft.onto.base_ontology.ConstituentNode"
+       }
+     ]
     }
   ]
 }


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/233. 

### Description of changes
The generator has the `self_ref` functionalities, but it is removed in one of the early commits. This fix reverts it back.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Added such self-referencing types in two different test ontology files.
