### PR TITLE
Serialize

### DIFF
--- a/forte/data/readers/deserialize_reader.py
+++ b/forte/data/readers/deserialize_reader.py
@@ -110,7 +110,10 @@ class MultiPackDeserializerBase(MultiPackReader):
       information.
     """
 
-    def _collect(self) -> Iterator[Any]:  # type: ignore
+    def __init__(self):
+        super().__init__()
+
+    def _collect(self) -> Iterator[Any]:
         """
         This collect actually do not need any data source, it directly reads
         the data from the configurations.

--- a/forte/data/readers/deserialize_reader.py
+++ b/forte/data/readers/deserialize_reader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 from abc import ABC, abstractmethod
+from typing import Iterator, List, Any, Dict
 
 from typing import Iterator, List, Any
 
@@ -110,10 +111,7 @@ class MultiPackDeserializerBase(MultiPackReader):
       information.
     """
 
-    def __init__(self):
-        super().__init__()
-
-    def _collect(self) -> Iterator[Any]:
+    def _collect(self) -> Iterator[Any]:  # type: ignore
         """
         This collect actually do not need any data source, it directly reads
         the data from the configurations.

--- a/forte/data/readers/deserialize_reader.py
+++ b/forte/data/readers/deserialize_reader.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import sqlite3
 from abc import ABC, abstractmethod
-from typing import Iterator, List, Any, Dict
-
-from typing import Iterator, List, Any
+from typing import Iterator, List, Any, Tuple
 
 from forte.common.exception import ProcessExecutionException
 from forte.data.data_pack import DataPack
@@ -137,7 +136,8 @@ class MultiPackDeserializerBase(MultiPackReader):
         Implementation of this method should be responsible for yielding
          the raw content of the multi packs.
 
-        Returns:
+        Returns: An iterator of raw strings, each string is the content of a
+         particular multi-pack.
 
         """
         raise NotImplementedError
@@ -151,7 +151,8 @@ class MultiPackDeserializerBase(MultiPackReader):
         Args:
             pack_id: representing the id of the data pack.
 
-        Returns:
+        Returns: Return raw string that contains the data pack content
+         corresponding to the `pack_id`.
 
         """
         raise NotImplementedError
@@ -181,11 +182,58 @@ class MultiPackDirectoryReader(MultiPackDeserializerBase):
 
     @classmethod
     def default_configs(cls):
-        return {
+        config = super().default_configs()
+
+        config.update({
             "multi_pack_dir": None,
             "data_pack_dir": None,
             "pack_suffix": '.json'
-        }
+        })
+        return config
+
+
+def dump_packs_from_database(
+        database_path: str, output_path: str,
+        datapack_table_name='nlpviewer_backend_document',
+        multipack_table_name='nlpviewer_backend_crossdoc'
+):
+    """
+    This helper function convert the multi pack data from a database to disk.
+
+    This reader is useful for reading data from the early version of
+    the Stave annotation tool: https://github.com/asyml/stave.
+    """
+
+    pack_sub_dir = "packs"
+    multi_sub_dir = "multi"
+
+    conn = sqlite3.connect(database_path)
+    c = conn.cursor()
+
+    multi_pack_output = os.path.join(output_path, multi_sub_dir)
+
+    if not os.path.exists(multi_pack_output):
+        os.makedirs(multi_pack_output)
+
+    for name, m_pack in load_packs(c, multipack_table_name):
+        with open(os.path.join(multi_pack_output, name) + '.json',
+                  'w') as mp_out:
+            mp_out.write(m_pack)
+
+    pack_output = os.path.join(output_path, pack_sub_dir)
+
+    if not os.path.exists(pack_output):
+        os.makedirs(pack_output)
+
+    for name, pack_str in load_packs(c, datapack_table_name):
+        with open(os.path.join(pack_output, name) + '.json', 'w') as pack_out:
+            pack_out.write(pack_str)
+
+
+def load_packs(cursor: sqlite3.Cursor, table_name) -> Tuple[str, str]:
+    for _, name, pack_str, _ in cursor.execute(
+            f'SELECT * FROM {table_name}'):
+        yield name, pack_str
 
 
 # A short name for this class.

--- a/forte/data/readers/multipack_sentence_reader.py
+++ b/forte/data/readers/multipack_sentence_reader.py
@@ -47,7 +47,8 @@ class MultiPackSentenceReader(MultiPackReader):
         self.config = configs
 
     def _collect(self, text_directory: str) -> Iterator[Any]:  # type: ignore
-        return dataset_path_iterator_with_base(text_directory, '')
+        return dataset_path_iterator_with_base(
+            text_directory, self.config.suffix)
 
     def _cache_key_function(self, txt_path: str) -> str:
         return os.path.basename(txt_path)
@@ -113,9 +114,19 @@ class MultiPackSentenceReader(MultiPackReader):
         `"output_pack_name"`: str
             Name of the output pack. This name can be used to retrieve the
             output pack from the multipack.
+
+        `"suffix"`: str
+            The suffix of the file to be read in. If not provided,
+            all files under this directory will be read.
+
         """
-        return {
-            "name": "multipack_sentence_reader",
-            "input_pack_name": "input_src",
-            "output_pack_name": "output_tgt"
-        }
+        params = super().default_configs()
+        params.update(
+            {
+                "name": "multipack_sentence_reader",
+                "input_pack_name": "input_src",
+                "output_pack_name": "output_tgt",
+                "suffix": '',
+            }
+        )
+        return params

--- a/forte/processors/base/writers.py
+++ b/forte/processors/base/writers.py
@@ -152,12 +152,10 @@ class MultiPackWriter(MultiPackProcessor):
         ensure_dir(pack_paths)
         self.pack_idx_out = open(pack_paths, 'w')
 
-        multi_index = os.path.join(self.configs.output_dir, self.multi_idx)
-        ensure_dir(multi_index)
-        self.multi_idx_out = open(multi_index, 'w')
-
     def pack_name(self, pack: DataPack) -> str:
-        r"""Allow defining output name using the information of the datapack.
+        r"""This function defines the output file name using the
+          information of the datapack. The default is to use
+          the `pack_id` of this `pack`.
 
         Args:
             pack: The input datapack.
@@ -165,12 +163,14 @@ class MultiPackWriter(MultiPackProcessor):
         return f"{pack.pack_id}"
 
     def multipack_name(self, pack: MultiPack) -> str:
-        r"""Allow defining output path using the information of the multipack.
+        r"""This function defines the output path using the information of
+        the multipack. The default implementation here is to use the `pack_id`
+        of this `pack`.
 
         Args:
             pack: The input multipack.
         """
-        return f"mult_pack_{pack.pack_id}"
+        return f"multi_pack_{pack.pack_id}"
 
     def _process(self, input_pack: MultiPack):
         multi_out_dir = os.path.join(self.configs.output_dir, self.multi_base)
@@ -186,20 +186,15 @@ class MultiPackWriter(MultiPackProcessor):
                 f'{pack.meta.pack_id}\t'
                 f'{posixpath.relpath(pack_out, self.configs.output_dir)}\n')
 
-        multi_out = write_pack(
+        write_pack(
             input_pack, multi_out_dir,
             self.multipack_name(input_pack), self.configs.indent,
             self.configs.zip_pack, self.configs.overwrite,
             self.configs.drop_record
         )
 
-        self.multi_idx_out.write(
-            f'{input_pack.meta.pack_id}\t'
-            f'{posixpath.relpath(multi_out, self.configs.output_dir)}\n')
-
     def finish(self, _):
         self.pack_idx_out.close()
-        self.multi_idx_out.close()
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:

--- a/tests/forte/data/readers/deserialize_reader_test.py
+++ b/tests/forte/data/readers/deserialize_reader_test.py
@@ -14,10 +14,17 @@
 """
 Unit tests for Deserialize Reader.
 """
+import os
+import sqlite3
+import tempfile
 import unittest
 
+from ddt import data, ddt
+
 from forte.data.data_pack import DataPack
-from forte.data.readers import StringReader, RawDataDeserializeReader
+from forte.data.readers import StringReader, RawDataDeserializeReader, \
+    MultiPackSentenceReader
+from forte.data.readers.deserialize_reader import dump_packs_from_database
 from forte.pipeline import Pipeline
 
 
@@ -40,6 +47,85 @@ class DeserializeReaderPipelineTest(unittest.TestCase):
             for new_pack in another_pipeline.process_dataset(
                     [pack.serialize()]):
                 self.assertEqual(pack.text, new_pack.text)
+
+
+@ddt
+class DatabaseLoadingTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+        self.db_path = os.path.join(self.test_dir, 'db.sqlite3')
+
+        sql_create_mp_table = """ CREATE TABLE IF NOT EXISTS 
+        nlpviewer_backend_crossdoc (
+            id integer PRIMARY KEY,
+            name varchar(200) NOT NULL,
+            textPack text NOT NULL,
+            ontology text NOT NULL
+        ); """
+
+        sql_create_pack_table = """ CREATE TABLE IF NOT EXISTS 
+        nlpviewer_backend_document (
+            id integer PRIMARY KEY,
+            name varchar(200) NOT NULL,
+            textPack text NOT NULL,
+            ontology text NOT NULL
+        ); """
+
+        self.conn = sqlite3.connect(self.db_path)
+        if self.conn is not None:
+            self.conn.cursor().execute(sql_create_mp_table)
+            self.conn.cursor().execute(sql_create_pack_table)
+
+        onto_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                 *([os.path.pardir] * 4),
+                                                 'forte', 'ontology_specs',
+                                                 'base_ontology.json'))
+
+        with open(onto_path) as onto:
+            self.onto_text = onto.read()
+
+    def add_data(self, table_name, name, pack_str):
+        sql = f''' INSERT INTO {table_name}(name, textPack, ontology) 
+                    VALUES(?,?,?)'''
+        cur = self.conn.cursor()
+        cur.execute(sql, (name, pack_str, self.onto_text))
+        self.conn.commit()
+
+    @data("This file is used for testing MultiPackSentenceReader.",
+          "This tool is called Forte.\n",
+          "The goal of this project to help you build NLP pipelines.\n"
+          "NLP has never been made this easy before.")
+    def test_database_load(self, text):
+        file_path = os.path.join(self.test_dir, 'test.txt')
+        with open(file_path, 'w') as f:
+            f.write(text)
+
+        pl = Pipeline()
+        pl.set_reader(MultiPackSentenceReader(), {"suffix": ".txt"})
+        pl.initialize()
+
+        multipack = pl.process(self.test_dir)
+        src_pack = multipack.get_pack('input_src')
+        tgt_pack = multipack.get_pack('output_tgt')
+
+        self.add_data('nlpviewer_backend_crossdoc', 'multi',
+                      multipack.serialize())
+        self.add_data('nlpviewer_backend_document', 'pack1',
+                      src_pack.serialize())
+        self.add_data('nlpviewer_backend_document', 'pack2',
+                      tgt_pack.serialize())
+
+        dump_packs_from_database(self.db_path, self.test_dir)
+        self.assertTrue(os.path.exists(os.path.join(self.test_dir, 'packs')))
+        self.assertTrue(os.path.exists(os.path.join(self.test_dir, 'multi')))
+
+        self.assertTrue(os.path.exists(
+            os.path.join(self.test_dir, 'multi', 'multi.json')))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.test_dir, 'packs', 'pack1.json')))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.test_dir, 'packs', 'pack2.json')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds methods to read data from the SQLite database (created from Stave).

Description of changes
Add a utility to dump data onto the disk from the database.

Currently, it is not easy to directly read from the database since the ids of the documents are not stored in the table.

Possible influences of this PR.
Describe what are the possible side-effects of the code change.

Test Conducted
Added a test case for this function.
