### PR TITLE
Removing new_pack entirely.

### DIFF
--- a/examples/Cliner/reader.py
+++ b/examples/Cliner/reader.py
@@ -28,7 +28,7 @@ class ClinerReader(PackReader):
     def _parse_pack(self, collection) -> Iterator[DataPack]:
         txt_path = collection
 
-        pack = self.new_pack(pack_name='Cliner_input')
+        pack = DataPack(pack_name='Cliner_input')
         with open(txt_path, "r", encoding="utf-8") as doc_file:
             doc = doc_file.readlines()
             offsets = []

--- a/examples/content_rewriter/reader.py
+++ b/examples/content_rewriter/reader.py
@@ -29,7 +29,7 @@ class TableReader(PackReader):
                     yield line.split(':', 1)[1].strip()
 
     def _parse_pack(self, table: str) -> Iterator[DataPack]:
-        p: DataPack = self.new_pack(pack_name='table_' + table.split("|")[0])
+        p: DataPack = DataPack(pack_name='table_' + table.split("|")[0])
         p.set_text(table)
 
         # Create the table.

--- a/examples/passage_ranker/reader.py
+++ b/examples/passage_ranker/reader.py
@@ -41,7 +41,7 @@ class EvalReader(MultiPackReader):
 
     def _parse_pack(self, data_source: str) -> Iterator[MultiPack]:
         fields = data_source.split("\t")
-        multi_pack = self.new_pack()
+        multi_pack = MultiPack()
 
         data_pack = multi_pack.add_pack(self.config.pack_name)
 

--- a/forte/data/datasets/wikipedia/dbpedia_based_reader.py
+++ b/forte/data/datasets/wikipedia/dbpedia_based_reader.py
@@ -161,7 +161,7 @@ class DBpediaWikiReader(PackReader):
     ) -> Iterator[DataPack]:
         str_data, node_data = doc_data
 
-        pack = self.new_pack()
+        pack = DataPack()
         doc_name: str = str_data['doc_name']
         if doc_name in self.redirects:
             doc_name = self.redirects[doc_name]

--- a/forte/data/readers/ag_news_reader.py
+++ b/forte/data/readers/ag_news_reader.py
@@ -71,7 +71,7 @@ class AGNewsReader(PackReader):
     def _parse_pack(self, line_info: Tuple[int, str]) -> Iterator[DataPack]:
         line_id, line = line_info
 
-        pack = self.new_pack()
+        pack = DataPack()
         text: str = ""
         line = line.strip()
         data = line.split(",")

--- a/forte/data/readers/base_reader.py
+++ b/forte/data/readers/base_reader.py
@@ -91,10 +91,6 @@ class BaseReader(PipelineComponent[PackType], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def new_pack(self, pack_name: Optional[str] = None) -> PackType:
-        raise NotImplementedError
-
-    @abstractmethod
     def _collect(self, *args: Any, **kwargs: Any) -> Iterator[Any]:
         r"""Returns an iterator of data objects, and each individual object
         should contain sufficient information needed to construct or locate
@@ -283,9 +279,6 @@ class PackReader(BaseReader[DataPack], ABC):
     def pack_type(self):
         return DataPack
 
-    def new_pack(self, pack_name: Optional[str] = None) -> DataPack:
-        return DataPack(pack_name)
-
     def set_text(self, pack: DataPack, text: str):
         r"""Assign the text value to the :class:`DataPack`. This function will
         pass the ``text_replace_operation`` to the :class:`DataPack` to conduct
@@ -306,6 +299,3 @@ class MultiPackReader(BaseReader[MultiPack], ABC):
     @property
     def pack_type(self):
         return MultiPack
-
-    def new_pack(self, pack_name: Optional[str] = None) -> MultiPack:
-        return MultiPack(pack_name)

--- a/forte/data/readers/conll03_reader.py
+++ b/forte/data/readers/conll03_reader.py
@@ -48,7 +48,7 @@ class CoNLL03Reader(PackReader):
         return os.path.basename(conll_file)
 
     def _parse_pack(self, file_path: str) -> Iterator[DataPack]:
-        pack = self.new_pack()
+        pack = DataPack()
         doc = codecs.open(file_path, "r", encoding="utf8")
 
         text = ""

--- a/forte/data/readers/conllu_ud_reader.py
+++ b/forte/data/readers/conllu_ud_reader.py
@@ -75,7 +75,7 @@ class ConllUDReader(PackReader):
 
         token_feature_fields = ["ud_features", "ud_misc"]
 
-        data_pack: DataPack = self.new_pack()
+        data_pack: DataPack = DataPack()
         doc_sent_begin: int = 0
         doc_num_sent: int = 0
         doc_text: str = ''

--- a/forte/data/readers/html_reader.py
+++ b/forte/data/readers/html_reader.py
@@ -273,7 +273,7 @@ class HTMLReader(PackReader):
 
         Returns: DataPack containing Document.
         """
-        pack = self.new_pack()
+        pack = DataPack()
 
         # Check if data_source is a filepath
         if self.init_with_fileloc:

--- a/forte/data/readers/largemovie_reader.py
+++ b/forte/data/readers/largemovie_reader.py
@@ -87,7 +87,7 @@ class LargeMovieReader(PackReader):
         return dataset_path_iterator(movie_directory, "txt")
 
     def _parse_pack(self, file_path: str) -> Iterator[DataPack]:
-        data_pack: DataPack = self.new_pack()
+        data_pack: DataPack = DataPack()
 
         sent_begin: int = 0
         doc_text: str = ""

--- a/forte/data/readers/ms_marco_passage_reader.py
+++ b/forte/data/readers/ms_marco_passage_reader.py
@@ -69,7 +69,7 @@ class MSMarcoPassageReader(PackReader):
 
         Returns: query or document data_pack.
         """
-        data_pack: DataPack = self.new_pack()
+        data_pack: DataPack = DataPack()
 
         doc_id, doc_text = doc_info
         data_pack.pack_name = doc_id

--- a/forte/data/readers/multipack_sentence_reader.py
+++ b/forte/data/readers/multipack_sentence_reader.py
@@ -56,7 +56,7 @@ class MultiPackSentenceReader(MultiPackReader):
                     base_and_path: Tuple[str, str]) -> Iterator[MultiPack]:
         base_dir, file_path = base_and_path
 
-        m_pack: MultiPack = self.new_pack()
+        m_pack: MultiPack = MultiPack()
 
         input_pack_name = self.config.input_pack_name
         output_pack_name = self.config.output_pack_name

--- a/forte/data/readers/multipack_terminal_reader.py
+++ b/forte/data/readers/multipack_terminal_reader.py
@@ -68,7 +68,7 @@ class MultiPackTerminalReader(MultiPackReader):
 
         Returns: MultiPack containing a datapack for the current query.
         """
-        multi_pack = self.new_pack()
+        multi_pack = MultiPack()
 
         # use context to build the query
         if self.resource.get("user_utterance"):

--- a/forte/data/readers/ontonotes_reader.py
+++ b/forte/data/readers/ontonotes_reader.py
@@ -141,7 +141,7 @@ class OntonotesReader(PackReader):
         return self.ParsedFields(**fields)  # type: ignore
 
     def _parse_pack(self, file_path: str) -> Iterator[DataPack]:
-        pack = self.new_pack()
+        pack = DataPack()
 
         with open(file_path, encoding="utf8") as doc:
             words = []

--- a/forte/data/readers/openie_reader.py
+++ b/forte/data/readers/openie_reader.py
@@ -81,7 +81,7 @@ class OpenIEReader(PackReader):
         return os.path.basename(oie_file)
 
     def _parse_pack(self, file_path: str) -> Iterator[DataPack]:
-        pack: DataPack = self.new_pack()
+        pack: DataPack = DataPack()
         text: str = ""
         offset: int = 0
 

--- a/forte/data/readers/plaintext_reader.py
+++ b/forte/data/readers/plaintext_reader.py
@@ -50,7 +50,7 @@ class PlainTextReader(PackReader):
         return []
 
     def _parse_pack(self, file_path: str) -> Iterator[DataPack]:
-        pack = self.new_pack()
+        pack = DataPack()
 
         with open(file_path, "r", encoding="utf8", errors='ignore') as file:
             text = file.read()

--- a/forte/data/readers/prodigy_reader.py
+++ b/forte/data/readers/prodigy_reader.py
@@ -60,7 +60,7 @@ class ProdigyReader(PackReader):
 
         Returns: DataPack containing information extracted from `data`.
         """
-        pack = self.new_pack()
+        pack = DataPack()
         text = data['text']
         pack.set_text(text, replace_func=self.text_replace_operation)
 

--- a/forte/data/readers/race_multi_choice_qa_reader.py
+++ b/forte/data/readers/race_multi_choice_qa_reader.py
@@ -60,7 +60,7 @@ class RACEMultiChoiceQAReader(PackReader):
         with open(file_path, "r", encoding="utf8", errors='ignore') as file:
             dataset = json.load(file)
 
-            pack = self.new_pack()
+            pack = DataPack()
             text: str = dataset['article']
             article_end = len(text)
             offset = article_end + 1

--- a/forte/data/readers/sem_eval_task8_reader.py
+++ b/forte/data/readers/sem_eval_task8_reader.py
@@ -73,7 +73,7 @@ class SemEvalTask8Reader(PackReader):
             self.configs.sem_eval_task8_file_extension)
 
     def _parse_pack(self, file_path: str) -> Iterator[DataPack]:
-        pack: DataPack = self.new_pack()
+        pack: DataPack = DataPack()
 
         with open(file_path, 'r', encoding='utf8') as fp:
             txt = ""

--- a/forte/data/readers/sst2_reader.py
+++ b/forte/data/readers/sst2_reader.py
@@ -220,7 +220,7 @@ class SST2Reader(PackReader):
         node_list[0].is_root = True
 
     def _parse_pack(self, sent_lines) -> Iterator[DataPack]:
-        data_pack: DataPack = self.new_pack()
+        data_pack: DataPack = DataPack()
         sent_bias: int = 0
         batch_text: str = "\n".join(
             [sent_text for _, sent_text, _ in sent_lines]

--- a/forte/data/readers/string_reader.py
+++ b/forte/data/readers/string_reader.py
@@ -56,7 +56,7 @@ class StringReader(PackReader):
 
         Returns: :class:`DataPack` containing Document.
         """
-        pack = self.new_pack()
+        pack = DataPack()
 
         self.set_text(pack, data_source)
         Document(pack, 0, len(data_source))

--- a/forte/processors/base/base_processor.py
+++ b/forte/processors/base/base_processor.py
@@ -38,20 +38,6 @@ class BaseProcessor(PipelineComponent[PackType], ABC):
         super().__init__()
         self.selector = DummySelector()
 
-    @abstractmethod
-    def new_pack(self, pack_name: Optional[str] = None) -> PackType:
-        """
-        Create a new pack using the current pack manager.
-
-        Args:
-            pack_name (str, Optional): The name to be used for the pack. If not
-              set, the pack name will remained unset.
-
-        Returns:
-
-        """
-        raise NotImplementedError
-
     def process(self, input_pack: PackType):
         # Set the component for recording purpose.
         input_pack.set_control_component(self.name)

--- a/forte/processors/base/base_processor.py
+++ b/forte/processors/base/base_processor.py
@@ -17,7 +17,7 @@ Base class for processors.
 
 import itertools
 from abc import abstractmethod, ABC
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from forte.data.base_pack import PackType
 from forte.data.selector import DummySelector

--- a/forte/processors/base/batch_processor.py
+++ b/forte/processors/base/batch_processor.py
@@ -241,9 +241,6 @@ class BatchProcessor(BaseBatchProcessor[DataPack], ABC):
                     entry_type
                 )
 
-    def new_pack(self, pack_name: Optional[str] = None) -> DataPack:
-        return DataPack(pack_name)
-
 
 class FixedSizeBatchProcessor(BatchProcessor, ABC):
     @staticmethod
@@ -268,9 +265,6 @@ class MultiPackBatchProcessor(BaseBatchProcessor[MultiPack], ABC):
                 p = input_pack.packs[self.input_pack_name]
                 p.index.build_coverage_index(
                     p, self.context_type, entry_type)
-
-    def new_pack(self, pack_name: Optional[str] = None) -> MultiPack:
-        return MultiPack(pack_name)
 
 
 class FixedSizeMultiPackBatchProcessor(MultiPackBatchProcessor, ABC):

--- a/forte/processors/base/pack_processor.py
+++ b/forte/processors/base/pack_processor.py
@@ -45,19 +45,6 @@ class PackProcessor(BaseProcessor[DataPack], ABC):
     def _process(self, input_pack: DataPack):
         raise NotImplementedError
 
-    def new_pack(self, pack_name: Optional[str] = None) -> DataPack:
-        """
-        Create a new pack based using the current pack manager.
-
-        Args:
-            pack_name (str, Optional): The name to be used for the pack. If not
-              set, the pack name will remained unset.
-
-        Returns:
-
-        """
-        return DataPack(pack_name)
-
 
 class MultiPackProcessor(BaseProcessor[MultiPack], ABC):
     r"""The base class of processors that process :class:`MultiPack` each time.
@@ -65,19 +52,6 @@ class MultiPackProcessor(BaseProcessor[MultiPack], ABC):
 
     def _process(self, input_pack: MultiPack):
         raise NotImplementedError
-
-    def new_pack(self, pack_name: Optional[str] = None) -> MultiPack:
-        """
-        Create a new multi pack using the current pack manager.
-
-        Args:
-            pack_name (str, Optional): The name to be used for the pack. If not
-              set, the pack name will remained unset.
-
-        Returns:
-
-        """
-        return MultiPack(pack_name)
 
     def new_data_pack(self, pack_name: Optional[str] = None) -> DataPack:
         """

--- a/tests/forte/data/entry_data_structures_test.py
+++ b/tests/forte/data/entry_data_structures_test.py
@@ -74,7 +74,7 @@ class EmptyReader(PackReader):
         yield from names
 
     def _parse_pack(self, name: str) -> Iterator[DataPack]:
-        p = self.new_pack()
+        p = DataPack()
         p.pack_name = name
         yield p
 
@@ -108,7 +108,7 @@ class EmptyMultiReader(MultiPackReader):
         yield from names
 
     def _parse_pack(self, name: str) -> Iterator[MultiPack]:
-        p = self.new_pack()
+        p = MultiPack()
         p.pack_name = name
         yield p
 

--- a/tests/forte/pipeline_test.py
+++ b/tests/forte/pipeline_test.py
@@ -65,7 +65,7 @@ class SentenceReader(PackReader):
     def _parse_pack(self, file_path: str) -> Iterator[DataPack]:
         with open(file_path, "r", encoding="utf8") as doc:
             for line in doc:
-                pack = self.new_pack(file_path)
+                pack = DataPack(file_path)
                 line = line.strip()
                 if len(line) == 0:
                     continue
@@ -100,7 +100,7 @@ class MultiPackSentenceReader(MultiPackReader):
                 if len(line) == 0:
                     continue
 
-                m_pack = self.new_pack()
+                m_pack = DataPack()
                 pack = m_pack.add_pack('pack')
                 pack.set_text(line)
 

--- a/tests/forte/pipeline_test.py
+++ b/tests/forte/pipeline_test.py
@@ -100,7 +100,7 @@ class MultiPackSentenceReader(MultiPackReader):
                 if len(line) == 0:
                     continue
 
-                m_pack = DataPack()
+                m_pack = MultiPack()
                 pack = m_pack.add_pack('pack')
                 pack.set_text(line)
 


### PR DESCRIPTION
This PR removes `new_pack()` function from processors.

The `new_pack` function is required when some dependencies
are required between packs, so we need a manager to maintain
them, now that we use uuid, we no longer need this function.

### Description of changes
Removing the `new_pack` function from the base classes and
all the calls to it.

### Possible influences of this PR.
Other projects that use `new_pack` may get affected.

### Test Conducted
Existing test cases should cover this PR.
