### PR TITLE
Support memory cached data pack inside reader

### DIFF
--- a/data_samples/base_reader_test/0.txt
+++ b/data_samples/base_reader_test/0.txt
@@ -1,0 +1,35 @@
+1. All you need to do is pick up the pen and begin.
+2. The knives were out and she was sharpening hers.
+3. So long and thanks for the fish.
+4. Rock music approaches at high velocity.
+He didn't heed the warning and it had turned out surprisingly well.
+She advised him to come back at once.
+A glittering gem is not enough.
+She could hear him in the shower singing with a joy she hoped he'd retain after she delivered the news.
+Check back tomorrow; I will see if the book has arrived.
+He had accidentally hacked into his company's server.
+All you need to do is pick up the pen and begin.
+She borrowed the book from him many years ago and hasn't yet returned it.
+There was no ice cream in the freezer, nor did they have money to go to the store.
+She always speaks to him in a loud voice.
+There is a fly in the car with us.
+It was the best sandcastle he had ever seen.
+The memory we used to share is no longer coherent.
+Italy is my favorite country; in fact, I plan to spend two weeks there next year.
+My Mum tries to be cool by saying that she likes all the same things that I do.
+How do you like RandomWordGenerator.com?
+A song can make or ruin a person’s day if they let it get to them.
+Oh, how I'd love to go!
+A glittering gem is not enough.
+The pizza smells delicious.
+I hope that, when I've built up my savings, I'll be able to travel to Mexico.
+Not all people who wander are lost.
+Yeah, I think it's a good environment for learning English.
+He didn't heed the warning and it had turned out surprisingly well.
+I would have gotten the promotion, but my attendance wasn’t good enough.
+I want to buy a onesie… but know it won’t suit me.
+It was getting dark, and we weren’t there yet.
+Did you know that, along with gorgeous architecture, it's home to the largest tamale?
+Joe made the sugar cookies; Susan decorated them.
+Brad came to dinner with us.
+So long and thanks for the fish.

--- a/data_samples/base_reader_test/1.txt
+++ b/data_samples/base_reader_test/1.txt
@@ -1,0 +1,35 @@
+1. All you need to do is pick up the pen and begin.
+2. The knives were out and she was sharpening hers.
+3. So long and thanks for the fish.
+4. Rock music approaches at high velocity.
+He didn't heed the warning and it had turned out surprisingly well.
+She advised him to come back at once.
+A glittering gem is not enough.
+She could hear him in the shower singing with a joy she hoped he'd retain after she delivered the news.
+Check back tomorrow; I will see if the book has arrived.
+He had accidentally hacked into his company's server.
+All you need to do is pick up the pen and begin.
+She borrowed the book from him many years ago and hasn't yet returned it.
+There was no ice cream in the freezer, nor did they have money to go to the store.
+She always speaks to him in a loud voice.
+There is a fly in the car with us.
+It was the best sandcastle he had ever seen.
+The memory we used to share is no longer coherent.
+Italy is my favorite country; in fact, I plan to spend two weeks there next year.
+My Mum tries to be cool by saying that she likes all the same things that I do.
+How do you like RandomWordGenerator.com?
+A song can make or ruin a person’s day if they let it get to them.
+Oh, how I'd love to go!
+A glittering gem is not enough.
+The pizza smells delicious.
+I hope that, when I've built up my savings, I'll be able to travel to Mexico.
+Not all people who wander are lost.
+Yeah, I think it's a good environment for learning English.
+He didn't heed the warning and it had turned out surprisingly well.
+I would have gotten the promotion, but my attendance wasn’t good enough.
+I want to buy a onesie… but know it won’t suit me.
+It was getting dark, and we weren’t there yet.
+Did you know that, along with gorgeous architecture, it's home to the largest tamale?
+Joe made the sugar cookies; Susan decorated them.
+Brad came to dinner with us.
+So long and thanks for the fish.

--- a/data_samples/base_reader_test/2.txt
+++ b/data_samples/base_reader_test/2.txt
@@ -1,0 +1,35 @@
+1. All you need to do is pick up the pen and begin.
+2. The knives were out and she was sharpening hers.
+3. So long and thanks for the fish.
+4. Rock music approaches at high velocity.
+He didn't heed the warning and it had turned out surprisingly well.
+She advised him to come back at once.
+A glittering gem is not enough.
+She could hear him in the shower singing with a joy she hoped he'd retain after she delivered the news.
+Check back tomorrow; I will see if the book has arrived.
+He had accidentally hacked into his company's server.
+All you need to do is pick up the pen and begin.
+She borrowed the book from him many years ago and hasn't yet returned it.
+There was no ice cream in the freezer, nor did they have money to go to the store.
+She always speaks to him in a loud voice.
+There is a fly in the car with us.
+It was the best sandcastle he had ever seen.
+The memory we used to share is no longer coherent.
+Italy is my favorite country; in fact, I plan to spend two weeks there next year.
+My Mum tries to be cool by saying that she likes all the same things that I do.
+How do you like RandomWordGenerator.com?
+A song can make or ruin a person’s day if they let it get to them.
+Oh, how I'd love to go!
+A glittering gem is not enough.
+The pizza smells delicious.
+I hope that, when I've built up my savings, I'll be able to travel to Mexico.
+Not all people who wander are lost.
+Yeah, I think it's a good environment for learning English.
+He didn't heed the warning and it had turned out surprisingly well.
+I would have gotten the promotion, but my attendance wasn’t good enough.
+I want to buy a onesie… but know it won’t suit me.
+It was getting dark, and we weren’t there yet.
+Did you know that, along with gorgeous architecture, it's home to the largest tamale?
+Joe made the sugar cookies; Susan decorated them.
+Brad came to dinner with us.
+So long and thanks for the fish.

--- a/forte/data/readers/base_reader.py
+++ b/forte/data/readers/base_reader.py
@@ -79,6 +79,7 @@ class BaseReader(PipelineComponent[PackType], ABC):
         super().initialize(resources, configs)
 
         # Clear memory cache
+        self._cache_ready = False
         del self._data_packs[:]
 
     @classmethod

--- a/forte/data/readers/base_reader.py
+++ b/forte/data/readers/base_reader.py
@@ -20,6 +20,7 @@ from abc import abstractmethod, ABC
 from pathlib import Path
 from typing import Any, Iterator, Optional, Union, List
 
+from forte.common.configuration import Config
 from forte.common.exception import ProcessExecutionException
 from forte.common.resources import Resources
 from forte.data import data_utils
@@ -73,6 +74,12 @@ class BaseReader(PipelineComponent[PackType], ABC):
         self._cache_in_memory = cache_in_memory
         self._cache_ready: bool = False
         self._data_packs: List[PackType] = []
+
+    def initialize(self, resources: Resources, configs: Config):
+        super().initialize(resources, configs)
+
+        # Clear memory cache
+        del self._data_packs[:]
 
     @classmethod
     def default_configs(cls):

--- a/forte/data/readers/base_reader.py
+++ b/forte/data/readers/base_reader.py
@@ -18,7 +18,7 @@ import logging
 import os
 from abc import abstractmethod, ABC
 from pathlib import Path
-from typing import Any, Iterator, Optional, Union
+from typing import Any, Iterator, Optional, Union, List
 
 from forte.common.exception import ProcessExecutionException
 from forte.common.resources import Resources
@@ -72,7 +72,7 @@ class BaseReader(PipelineComponent[PackType], ABC):
         self.append_to_cache = append_to_cache
         self._cache_in_memory = cache_in_memory
         self._cache_ready: bool = False
-        self._data_packs = []
+        self._data_packs: List[PackType] = []
 
     @classmethod
     def default_configs(cls):

--- a/tests/forte/data/readers/base_reader_test.py
+++ b/tests/forte/data/readers/base_reader_test.py
@@ -1,0 +1,65 @@
+# Copyright 2019 The Forte Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for BaseReader.
+"""
+
+import unittest
+from typing import List
+
+from forte.data.data_pack import DataPack
+from forte.data.readers.plaintext_reader import PlainTextReader
+from forte.processors.base.pack_processor import PackProcessor
+from forte.pipeline import Pipeline
+
+
+class DummyPackProcessor(PackProcessor):
+
+    def _process(self, input_pack: DataPack):
+        pass
+
+
+class BaseReaderTest(unittest.TestCase):
+
+    def setUp(self):
+        # Define and config the Pipeline
+        self.dataset_path = "data_samples/base_reader_test/"
+
+        self.nlp = Pipeline[DataPack]()
+
+        self.reader = PlainTextReader(cache_in_memory=True)
+        self.nlp.set_reader(self.reader)
+        self.nlp.add(DummyPackProcessor())
+
+        self.nlp.initialize()
+
+    def test_memory_cache(self):
+        parsed_packs: List[DataPack] = []
+
+        for pack in self.nlp.process_dataset(self.dataset_path):
+            parsed_packs.append(pack)
+
+        self.assertTrue(self.reader._cache_ready)
+        self.assertEqual(len(self.reader._data_packs), 3)
+        self.assertEqual(parsed_packs, self.reader._data_packs)
+
+        # Test reinitialize will clear memory cache
+        self.nlp.initialize()
+
+        self.assertFalse(self.reader._cache_ready)
+        self.assertTrue(len(self.reader._data_packs) == 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes #315.

### Description of changes
Track parsed data pack in side reader and retrieve those data packs instead of re-parsing from disk file when the `iter` method is called the second time.

### Possible influences of this PR.
Default is do not cache in memory so it should have no side-effect for current readers.

### Test Conducted
N/A