### PR TITLE
Update predicate argument span start/end detection and read multiple documents in one file - Ontonotes Reader

### DIFF
--- a/data_samples/ontonotes/nested_spans/abc_0009.gold_conll
+++ b/data_samples/ontonotes/nested_spans/abc_0009.gold_conll
@@ -1,0 +1,62 @@
+#begin document (bn/abc/00/abc_0009); part 000
+bn/abc/00/abc_0009   0    0    Tomorrow     NN  (TOP(S(NP(NP*       -    -   -   -      (DATE)       (ARG0(ARG1*)*)      (9
+bn/abc/00/abc_0009   0    1          's    POS              *)      -    -   -   -          *             *        -
+bn/abc/00/abc_0009   0    2      summit     NN              *       -    -   -   -          *             *        -
+bn/abc/00/abc_0009   0    3     meeting     NN              *)      -    -   -   -          *             *        9)
+bn/abc/00/abc_0009   0    4        will     MD           (VP*       -    -   -   -          *             *        -
+bn/abc/00/abc_0009   0    5       bring     VB           (VP*    bring  01   1   -          *           (V*)       -
+bn/abc/00/abc_0009   0    6        Ehud    NNP        (NP(NP*       -    -   -   -   (PERSON*        (ARG2(ARG3*)   (3|(11
+bn/abc/00/abc_0009   0    7       Barak    NNP              *)      -    -   -   -          *)            *        3)
+bn/abc/00/abc_0009   0    8         and     CC              *       -    -   -   -          *             *        -
+bn/abc/00/abc_0009   0    9      Yasser    NNP           (NP*       -    -   -   -   (PERSON*             *       (8
+bn/abc/00/abc_0009   0   10      Arafat    NNP             *))      -    -   -   -          *)            *)   11)|8)
+bn/abc/00/abc_0009   0   11          to     IN           (PP*       -    -   -   -          *        (ARG4(ARG5*   -
+bn/abc/00/abc_0009   0   12         the     DT        (NP(NP*       -    -   -   -          *             *        -
+bn/abc/00/abc_0009   0   13      resort     NN              *       -    -   -   -          *             *        -
+bn/abc/00/abc_0009   0   14        city     NN              *)      -    -   -   -          *             *        -
+bn/abc/00/abc_0009   0   15          of     IN           (PP*       -    -   -   -          *             *)       -
+bn/abc/00/abc_0009   0   16       Sharm    NNP           (NP*       -    -   -   -      (GPE*             *        -
+bn/abc/00/abc_0009   0   17          El    NNP              *       -    -   -   -          *             *)       -
+bn/abc/00/abc_0009   0   18          -    HYPH              *       -    -   -   -          *             *        -
+bn/abc/00/abc_0009   0   19        eikh    NNP         *))))))      -    -   -   -          *)            *        -
+bn/abc/00/abc_0009   0   20           .      .             *))      -    -   -   -          *             *        -
+
+bn/abc/00/abc_0009   0    0            Both     DT      (TOP(S(NP*           -    -   -   -        *      *          *       (6
+bn/abc/00/abc_0009   0    1           sides    NNS               *)        side   -   3   -        *      *          *        6)
+bn/abc/00/abc_0009   0    2            have    VBP            (VP*         have  01   -   -        *    (V*)         *        -
+bn/abc/00/abc_0009   0    3          almost     RB          (ADVP*)          -    -   -   -        *      *          *        -
+bn/abc/00/abc_0009   0    4         stepped    VBN            (VP*         step  01   1   -        *      *          *        -
+bn/abc/00/abc_0009   0    5            back     RB          (ADVP*)          -    -   -   -        *      *          *        -
+bn/abc/00/abc_0009   0    6             six     CD         (NP(NP*           -    -   -   -   (DATE*      *          *       (1
+bn/abc/00/abc_0009   0    7           years    NNS              *))          -    -   -   -        *)  (ARG0         *        1)
+bn/abc/00/abc_0009   0    8              in     IN            (PP*           -    -   -   -        *      *          *        -
+bn/abc/00/abc_0009   0    9           terms    NNS         (NP(NP*)        term   -   9   -        *      *          *        -
+bn/abc/00/abc_0009   0   10              of     IN            (PP*           -    -   -   -        *      *          *        -
+bn/abc/00/abc_0009   0   11           their   PRP$            (NP*           -    -   -   -        *      *     (ARG0*)      (6)
+bn/abc/00/abc_0009   0   12      statements    NNS               *    statement  01   1   -        *   (ARG1       (V*)       -
+bn/abc/00/abc_0009   0   13             and     CC               *           -    -   -   -        *      *          *        -
+bn/abc/00/abc_0009   0   14       attitudes    NNS            *))))    attitude   -   1   -        *      *          *        -
+bn/abc/00/abc_0009   0   15               ,      ,               *           -    -   -   -        *      *)         *        -
+bn/abc/00/abc_0009   0   16             six     CD            (NP*           -    -   -   -   (DATE*      *          *       (1
+bn/abc/00/abc_0009   0   17           years    NNS               *           -    -   -   -        *      *          *        1)
+bn/abc/00/abc_0009   0   18              or     CC            (QP*           -    -   -   -        *      *)    (ARG1*        -
+bn/abc/00/abc_0009   0   19            more    JJR              *))          -    -   -   -        *)     *          *        -
+bn/abc/00/abc_0009   0   20             --       :               *           -    -   -   -        *      *          *        -
+bn/abc/00/abc_0009   0   21          before     IN            (PP*           -    -   -   -        *      *     (ARG2*        -
+bn/abc/00/abc_0009   0   22             the     DT         (NP(NP*           -    -   -   -    (LAW*      *          *        -
+bn/abc/00/abc_0009   0   23            Oslo    NNP               *           -    -   -   -        *      *          *        -
+bn/abc/00/abc_0009   0   24         accords    NNS               *)      accord   -   2   -        *)     *          *        -
+bn/abc/00/abc_0009   0   25               ,      ,               *           -    -   -   -        *      *        *))        -
+bn/abc/00/abc_0009   0   26            when    WRB   (SBAR(WHADVP*)          -    -   -   -        *      *          *        -
+bn/abc/00/abc_0009   0   27             the     DT        (S(S(NP*           -    -   -   -        *      *          *       (2
+bn/abc/00/abc_0009   0   28        Israelis   NNPS               *)          -    -   -   -    (NORP)     *          *        2)
+bn/abc/00/abc_0009   0   29        promised    VBD            (VP*      promise  01   1   -        *      *          *        -
+bn/abc/00/abc_0009   0   30            land     NN          (NP*)))        land   -   3   -        *      *          *        -
+bn/abc/00/abc_0009   0   31             and     CC               *           -    -   -   -        *      *          *        -
+bn/abc/00/abc_0009   0   32             the     DT          (S(NP*           -    -   -   -        *      *          *      (15
+bn/abc/00/abc_0009   0   33    Palestinians   NNPS               *)          -    -   -   -    (NORP)     *          *       15)
+bn/abc/00/abc_0009   0   34        promised    VBD            (VP*      promise  01   1   -        *      *          *        -
+bn/abc/00/abc_0009   0   35        security     NN    (NP*)))))))))    security   -   3   -        *      *          *        -
+bn/abc/00/abc_0009   0   36               .      .              *))          -    -   -   -        *      *          *        -
+
+#end document

--- a/forte/data/readers/ontonotes_reader.py
+++ b/forte/data/readers/ontonotes_reader.py
@@ -30,6 +30,8 @@ __all__ = [
     "OntonotesReader",
 ]
 
+Stack = List[Tuple[int, str]]
+
 
 class OntonotesReader(PackReader):
     r""":class:`OntonotesReader` is designed to read in the English OntoNotes
@@ -159,7 +161,7 @@ class OntonotesReader(PackReader):
                     current_entity_mention: Optional[Tuple[int, str]] = None
                     verbal_predicates: List[PredicateMention] = []
 
-                    current_pred_arg: List[Optional[Tuple[int, str]]] = []
+                    current_pred_arg: List[Stack] = []
                     verbal_pred_args: List[
                         List[Tuple[PredicateArgument, str]]] = []
 
@@ -234,7 +236,7 @@ class OntonotesReader(PackReader):
                             verbal_predicates.append(pred_mention)
 
                     if not verbal_pred_args:
-                        current_pred_arg = [None] * len(fields.predicate_labels)
+                        current_pred_arg = [[] for _ in fields.predicate_labels]
                         verbal_pred_args = [[] for _ in fields.predicate_labels]
 
                     # add predicate arguments
@@ -322,39 +324,79 @@ class OntonotesReader(PackReader):
             labels: List[str],
             word_begin: int,
             word_end: int,
-            current_pred_arg: List[Optional[Tuple[int, str]]],
+            current_pred_arg: List[Stack],
             verbal_pred_args: List[List[Tuple[PredicateArgument, str]]],
     ) -> None:
+        """
+        Various cases will be handled regarding nested spans including:
+        case 1:
+        (xxx(xxx*)*)
 
+        case 2:
+        (xxx(xxx*)
+        *
+        *)
+
+        case 3:
+        (xxx(xxx*
+        *
+        *)
+        *
+        *)
+
+        case 4:
+        (xxx*
+        *
+        (xxx
+        *
+        *)
+        *
+        *)
+        Where the `xxx` represents an argument type.
+        A stack will be maintained to parse nested spans.
+        """
+        # TODO: currently all nested spans will be parsed but only outer most
+        #  span will be stored into datapack.
         for label_index, label in enumerate(labels):
-            # To find the span start/end, this is a workaround for input
-            # like `(ARG1(R-ARG2*)`. All inner spans will be ignored
             label = label.strip()
-            l_bracket_cnt, r_bracket_cnt = label.count('('), label.count(')')
-            is_span_start: bool = \
-                label[0] == '(' and l_bracket_cnt - r_bracket_cnt == 1
-            is_span_end: bool = \
-                label[-1] == ')' and r_bracket_cnt - l_bracket_cnt == 1
 
-            if is_span_start:
-                # Entering into a span
-                arg_type = label.strip("()*")
-                current_pred_arg[label_index] = (word_begin, arg_type)
+            arg_type: str = ""
+            i: int = 0
+            while i < len(label):
+                c: str = label[i]
+                if c == '*':
+                    i += 1
+                elif c == '(':
+                    # New argument span.
+                    j: int = i + 1
+                    while j < len(label):
+                        arg_type += label[j]
+                        if j == len(label) - 1 or label[j + 1] in ['(', ')']:
+                            break
+                        j += 1
+                    i = j + 1
+                    arg_type = arg_type.strip("* ")
 
-            if is_span_end:
-                # Exiting a span
-                if current_pred_arg[label_index] is None:
-                    raise ValueError(
-                        "current_pred_arg is None when meet right blanket.")
+                    stack: Stack = current_pred_arg[label_index]
+                    stack.append((word_begin, arg_type))
+                    arg_type = ""
+                elif c == ')':
+                    # End of current argument span.
+                    stack = current_pred_arg[label_index]
+                    assert len(stack) > 0, \
+                        "invalid parsing state: mismatch argument span"
 
-                arg_begin = current_pred_arg[label_index][0]  # type: ignore
-                arg_type = current_pred_arg[label_index][1]  # type: ignore
+                    arg_begin, arg_type = stack.pop()
 
-                if arg_type != "V":
-                    pred_arg = PredicateArgument(pack, arg_begin, word_end)
+                    if not stack:
+                        # The outer most span will be stored into data pack
+                        if arg_type != "V":
+                            pred_arg = PredicateArgument(pack, arg_begin,
+                                                         word_end)
 
-                    verbal_pred_args[label_index].append((pred_arg, arg_type))
-                current_pred_arg[label_index] = None
+                            verbal_pred_args[label_index].append(
+                                (pred_arg, arg_type))
+                    i += 1
 
     def _process_coref_annotations(
             self,

--- a/forte/data/readers/ontonotes_reader.py
+++ b/forte/data/readers/ontonotes_reader.py
@@ -148,7 +148,7 @@ class OntonotesReader(PackReader):
                 if start_new_doc:
                     pack = DataPack()
 
-                    words = []
+                    words: List = []
                     offset = 0
                     has_rows = False
 
@@ -332,9 +332,9 @@ class OntonotesReader(PackReader):
             label = label.strip()
             l_bracket_cnt, r_bracket_cnt = label.count('('), label.count(')')
             is_span_start: bool = \
-                label[0] == '(' and l_bracket_cnt-r_bracket_cnt == 1
+                label[0] == '(' and l_bracket_cnt - r_bracket_cnt == 1
             is_span_end: bool = \
-                label[-1] == ')' and r_bracket_cnt-l_bracket_cnt == 1
+                label[-1] == ')' and r_bracket_cnt - l_bracket_cnt == 1
 
             if is_span_start:
                 # Entering into a span


### PR DESCRIPTION
### Description of changes
Original, there are two issues for [OntonotesReader](https://github.com/asyml/forte/blob/master/forte/data/readers/ontonotes_reader.py):

* The `Predicate Argument` span start/end detection is not currect for nested span cases like `(ARG1(R-ARG2*)`

* There could be multiple documents in a single dataset file. However, the reader will only parse the first document in the file and ignore all subsequent documents in this file.

Regarding the first issue, a workaround is used to ignore all inner spans.
Regarding the second issue, now each document in a file will be parsed into a single `datapack`.

### Possible influences of this PR.
N/A

### Test Conducted
Will add unit testing for those two issue cases.
