### PR TITLE
Move deserialize into Pack classes

### DIFF
--- a/forte/data/base_pack.py
+++ b/forte/data/base_pack.py
@@ -141,6 +141,21 @@ class BasePack(EntryContainer[EntryType, LinkType, GroupType]):
         """
         self.meta.pack_name = pack_name
 
+    @classmethod
+    def _deserialize(cls, string: str) -> "PackType":
+        """
+        This function should deserialize a Pack from a string. The
+         implementation should decide the specific pack type.
+
+        Args:
+            string: The serialized string to be deserialized.
+
+        Returns:
+            An pack object deserialized from the string.
+        """
+        pack = jsonpickle.decode(string)
+        return pack
+
     @abstractmethod
     def delete_entry(self, entry: EntryType):
         r""" Remove the entry from the pack.

--- a/forte/data/data_pack.py
+++ b/forte/data/data_pack.py
@@ -307,6 +307,21 @@ class DataPack(BasePack[Entry, Link, Group]):
 
         return Span(orig_begin, orig_end)
 
+    @classmethod
+    def deserialize(cls, string: str) -> "DataPack":
+        """
+        Deserialize a Data Pack from a string. This internally calls the
+          internal :meth:`~forte.data.BasePack._deserialize` function from the
+          :class:`~forte.data.BasePack`.
+
+        Args:
+            string: The serialized string of a data pack to be deserialized.
+
+        Returns:
+            An data pack object deserialized from the string.
+        """
+        return cls._deserialize(string)
+
     def _add_entry(self, entry: EntryType) -> EntryType:
         r"""Force add an :class:`~forte.data.ontology.top.Entry` object to the
         :class:`DataPack` object. Allow duplicate entries in a pack.

--- a/forte/data/data_utils.py
+++ b/forte/data/data_utils.py
@@ -22,14 +22,11 @@ import urllib.request
 import zipfile
 from typing import List, Optional, overload
 
-import jsonpickle
-
 from forte.utils.types import PathLike
 from forte.utils.utils_io import maybe_create_dir
 
 __all__ = [
     "maybe_download",
-    "deserialize"
 ]
 
 
@@ -126,7 +123,8 @@ def _download(url: str, filename: str, path: str) -> str:
     filepath, _ = urllib.request.urlretrieve(url, filepath, _progress_hook)
     print()
     statinfo = os.stat(filepath)
-    print(f'Successfully downloaded {filename} {statinfo.st_size} bytes')
+    logging.info('Successfully downloaded %s %d bytes', filename,
+                 statinfo.st_size)
 
     return filepath
 
@@ -149,8 +147,9 @@ def _download_from_google_drive(url: str, filename: str, path: str) -> str:
     try:
         import requests
     except ImportError:
-        print("The requests library must be installed to download files from "
-              "Google drive. Please see: https://github.com/psf/requests")
+        logging.info(
+            "The requests library must be installed to download files from "
+            "Google drive. Please see: https://github.com/psf/requests")
         raise
 
     def _get_confirm_token(response):
@@ -177,18 +176,6 @@ def _download_from_google_drive(url: str, filename: str, path: str) -> str:
             if chunk:
                 f.write(chunk)
 
-    print(f'Successfully downloaded {filename}')
+    logging.info('Successfully downloaded %s', filename)
 
     return filepath
-
-
-def deserialize(string: str):
-    r"""Deserialize a pack from a string.
-    """
-    pack = jsonpickle.decode(string)
-    # Need to assign the pack manager to the pack to control it after reading
-    #  the raw data.
-    # pylint: disable=protected-access
-    # pack._pack_manager = pack_manager
-    # pack_manager.set_remapped_pack_id(pack)
-    return pack

--- a/forte/data/data_utils.py
+++ b/forte/data/data_utils.py
@@ -20,7 +20,6 @@ import sys
 import tarfile
 import urllib.request
 import zipfile
-from os import PathLike
 from typing import List, Optional, overload, Union
 
 from forte.utils.types import PathLike
@@ -28,7 +27,6 @@ from forte.utils.utils_io import maybe_create_dir
 
 __all__ = [
     "maybe_download",
-    "deserialize"
 ]
 
 

--- a/forte/data/datasets/wikipedia/dbpedia_infobox_reader.py
+++ b/forte/data/datasets/wikipedia/dbpedia_infobox_reader.py
@@ -29,7 +29,6 @@ import rdflib
 
 from forte.common import Resources
 from forte.common.configuration import Config
-from forte.data import data_utils
 from forte.data.data_pack import DataPack
 from forte.data.datasets.wikipedia.db_utils import (
     get_resource_name, NIFBufferedContextReader, ContextGroupedNIFReader,
@@ -123,7 +122,7 @@ class DBpediaInfoBoxReader(PackReader):
 
             if os.path.exists(pack_path):
                 with open(pack_path) as pack_file:
-                    pack = data_utils.deserialize(pack_file.read())
+                    pack: DataPack = DataPack.deserialize(pack_file.read())
 
                     add_info_boxes(pack, info_box_data['literals'])
                     add_info_boxes(pack, info_box_data['objects'])

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -489,6 +489,27 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         for entry_id in valid_id:
             yield self.get_entry(entry_id)
 
+    @classmethod
+    def deserialize(cls, string: str) -> "MultiPack":
+        """
+        Deserialize a Multi Pack from a string. Note that this will only
+          deserialize the native multipack content, which means the associated
+          DataPacks contained in the Multipack will not be recovered. A
+          followed-up step need to be performed to add the data packs back
+          to the multi pack.
+
+          This internally calls the
+          internal :meth:`~forte.data.BasePack._deserialize` function from the
+          :class:`~forte.data.BasePack`.
+
+        Args:
+            string: The serialized string of a Multi pack to be deserialized.
+
+        Returns:
+            An data pack object deserialized from the string.
+        """
+        return cls._deserialize(string)
+
     def _add_entry(self, entry: EntryType) -> EntryType:
         r"""Force add an :class:`Entry` object to the :class:`MultiPack` object.
 

--- a/forte/data/readers/base_reader.py
+++ b/forte/data/readers/base_reader.py
@@ -23,7 +23,6 @@ from typing import Any, Iterator, Optional, Union, List
 from forte.common.configuration import Config
 from forte.common.exception import ProcessExecutionException
 from forte.common.resources import Resources
-from forte.data import data_utils
 from forte.data.base_pack import PackType
 from forte.data.data_pack import DataPack
 from forte.data.multi_pack import MultiPack
@@ -283,7 +282,7 @@ class BaseReader(PipelineComponent[PackType], ABC):
         logger.info("reading from cache file %s", cache_filename)
         with open(cache_filename, "r") as cache_file:
             for line in cache_file:
-                pack = data_utils.deserialize(line.strip())
+                pack = DataPack.deserialize(line.strip())
                 if not isinstance(pack, self.pack_type):
                     raise TypeError(
                         f"Pack deserialized from {cache_filename} "

--- a/forte/data/readers/deserialize_reader.py
+++ b/forte/data/readers/deserialize_reader.py
@@ -18,7 +18,6 @@ from typing import Iterator, List, Any
 
 from forte.common.exception import ProcessExecutionException
 from forte.data.data_pack import DataPack
-from forte.data.data_utils import deserialize
 from forte.data.multi_pack import MultiPack
 from forte.data.readers.base_reader import PackReader, MultiPackReader
 
@@ -40,8 +39,7 @@ class BaseDeserializeReader(PackReader, ABC):
             raise ProcessExecutionException(
                 "Data source is None, cannot deserialize.")
 
-        # pack: DataPack = DataPack.deserialize(data_source)
-        pack: DataPack = deserialize(data_source)
+        pack: DataPack = DataPack.deserialize(data_source)
 
         if pack is None:
             raise ProcessExecutionException(
@@ -123,10 +121,10 @@ class MultiPackDeserializerBase(MultiPackReader):
 
     def _parse_pack(self, multi_pack_str: str) -> Iterator[MultiPack]:
         # pylint: disable=protected-access
-        m_pack: MultiPack = deserialize(multi_pack_str)
+        m_pack: MultiPack = MultiPack.deserialize(multi_pack_str)
 
         for pid in m_pack._pack_ref:
-            pack: DataPack = deserialize(self._get_pack_content(pid))
+            pack: DataPack = DataPack.deserialize(self._get_pack_content(pid))
             m_pack._packs.append(pack)
         yield m_pack
 

--- a/forte/data/readers/stave_readers.py
+++ b/forte/data/readers/stave_readers.py
@@ -24,7 +24,6 @@ from typing import Iterator, Dict
 from forte.common import Resources, ProcessorConfigError
 from forte.common.configuration import Config
 from forte.data.data_pack import DataPack
-from forte.data.data_utils import deserialize
 from forte.data.readers.base_reader import PackReader
 from forte.data.readers.deserialize_reader import MultiPackDeserializerBase
 
@@ -53,7 +52,7 @@ def load_all_datapacks(conn, pack_table_name: str, pack_col: int) -> Dict[
     data_packs: Dict[int, DataPack] = {}
     for val in c.execute(
             f'SELECT * FROM {pack_table_name}'):
-        pack: DataPack = deserialize(val[pack_col])
+        pack: DataPack = DataPack.deserialize(val[pack_col])
         # Currently assume we do not have access to the id in the database,
         #  once we update all Stave db format, we can add the real id.
         data_packs[pack.pack_id] = pack
@@ -138,7 +137,7 @@ class StaveDataPackSqlReader(PackReader):
             yield value[0]
 
     def _parse_pack(self, pack_str: str) -> Iterator[DataPack]:
-        yield deserialize(pack_str)
+        yield DataPack.deserialize(pack_str)
 
     @classmethod
     def default_configs(cls):

--- a/forte/processors/base/data_selector_for_da.py
+++ b/forte/processors/base/data_selector_for_da.py
@@ -26,7 +26,6 @@ from forte.common.resources import Resources
 from forte.common.configuration import Config
 from forte.data.data_pack import DataPack
 from forte.data.readers.base_reader import PackReader
-from forte.data.data_utils import deserialize
 from forte.indexers.elastic_indexer import ElasticSearchIndexer
 
 
@@ -62,7 +61,7 @@ class BaseElasticSearchDataSelector(BaseDataSelector):
         raise NotImplementedError
 
     def _parse_pack(self, pack_info: str) -> Iterator[DataPack]:
-        pack: DataPack = deserialize(pack_info)
+        pack: DataPack = DataPack.deserialize(pack_info)
         yield pack
 
     @classmethod


### PR DESCRIPTION
This PR moves the deserailize from `data_utils` to Pack classes.

### Description of changes
The deserialize function can be called directly from the Pack classes as class methods. The reasons are:
1. It is more intuitive to do deserialization from the individual classes.
2. The typing can be more clear by doing this.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Previous tests on the deserialization should cover this.