### PR TITLE
[vocab/extractor] use pickle to dump and load Vocabulary and Extractor

### DIFF
--- a/forte/data/extractor/base_extractor.py
+++ b/forte/data/extractor/base_extractor.py
@@ -119,19 +119,6 @@ class BaseExtractor(ABC):
             "need_pad": True,
         }
 
-    def __getstate__(self):
-        r"""For serializaion."""
-        state = {
-            "config": self.config,
-            "vocab": self.vocab
-        }
-        return state
-
-    def __setstate__(self, state):
-        r"""For deserialization."""
-        self.config = state["config"]
-        self.vocab = state["vocab"]
-
     @property
     def entry_type(self) -> Type[Annotation]:
         return self.config.entry_type

--- a/forte/data/extractor/base_extractor.py
+++ b/forte/data/extractor/base_extractor.py
@@ -119,31 +119,18 @@ class BaseExtractor(ABC):
             "need_pad": True,
         }
 
-    @property
-    def state(self) -> Dict:
-        return {
-            "vocab_method": self.config.vocab_method,
-            "need_pad": self.config.need_pad,
-            "vocab_use_unk": self.config.vocab_use_unk,
-            "entry_type": self.config.entry_type,
-            "vocab": self.vocab.state if self.vocab else None,
+    def __getstate__(self):
+        r"""For serializaion."""
+        state = {
+            "config": self.config,
+            "vocab": self.vocab
         }
+        return state
 
-    @classmethod
-    def from_state(cls, state: Dict) -> "BaseExtractor":
-        config = {
-            "vocab_method": state["vocab_method"],
-            "need_pad": state["need_pad"],
-            "vocab_use_unk": state["vocab_use_unk"],
-            "entry_type": state["entry_type"]
-        }
-        obj = cls(config)
-        if "vocab" in state and state["vocab"] is not None and \
-                isinstance(state["vocab"], dict):
-            obj.vocab = Vocabulary.from_state(state["vocab"])
-        else:
-            obj.vocab = None
-        return obj
+    def __setstate__(self, state):
+        r"""For deserialization."""
+        self.config = state["config"]
+        self.vocab = state["vocab"]
 
     @property
     def entry_type(self) -> Type[Annotation]:

--- a/forte/data/vocabulary.py
+++ b/forte/data/vocabulary.py
@@ -114,27 +114,6 @@ class Vocabulary:
         if use_unk:
             self.add_element(Vocabulary.UNK_ELEMENT)
 
-    def __getstate__(self):
-        r"""For serialization."""
-        state = {
-            "method": self.method,
-            "need_pad": self.need_pad,
-            "use_unk": self.use_unk,
-            "element2id_dict": self.element2id_dict,
-            "id2element_dict": self.id2element_dict,
-            "next_id": self.next_id
-        }
-        return state
-
-    def __setstate__(self, state):
-        r"""For deserialization."""
-        self.method = state["method"]
-        self.need_pad = state["need_pad"]
-        self.use_unk = state["use_unk"]
-        self.element2id_dict = state["element2id_dict"]
-        self.id2element_dict = state["id2element_dict"]
-        self.next_id = state["next_id"]
-
     def add_element(self, element: Hashable):
         r"""This function will add element to the vocabulary.
 

--- a/forte/data/vocabulary.py
+++ b/forte/data/vocabulary.py
@@ -114,24 +114,25 @@ class Vocabulary:
         if use_unk:
             self.add_element(Vocabulary.UNK_ELEMENT)
 
-    @property
-    def state(self) -> Dict:
-        return {
-            "method": self.method,
-            "need_pad": self.need_pad,
-            "use_unk": self.use_unk,
-            "element2id_dict": self.element2id_dict,
-            "id2element_dict": self.id2element_dict,
-            "next_id": self.next_id
-        }
+    def __getstate__(self):
+        r"""For serialization."""
+        state = {}
+        state["method"] = self.method
+        state["need_pad"] = self.need_pad
+        state["use_unk"] = self.use_unk
+        state["element2id_dict"] = self.element2id_dict
+        state["id2element_dict"] = self.id2element_dict
+        state["next_id"] = self.next_id
+        return state
 
-    @classmethod
-    def from_state(cls, state: Dict) -> "Vocabulary":
-        obj = cls(state["method"], state["need_pad"], state["use_unk"])
-        obj.element2id_dict = state["element2id_dict"]
-        obj.id2element_dict = state["id2element_dict"]
-        obj.next_id = state["next_id"]
-        return obj
+    def __setstate__(self, state):
+        r"""For deserialization."""
+        self.method = state["method"]
+        self.need_pad = state["need_pad"]
+        self.use_unk = state["use_unk"]
+        self.element2id_dict = state["element2id_dict"]
+        self.id2element_dict = state["id2element_dict"]
+        self.next_id = state["next_id"]
 
     def add_element(self, element: Hashable):
         r"""This function will add element to the vocabulary.

--- a/forte/data/vocabulary.py
+++ b/forte/data/vocabulary.py
@@ -116,13 +116,14 @@ class Vocabulary:
 
     def __getstate__(self):
         r"""For serialization."""
-        state = {}
-        state["method"] = self.method
-        state["need_pad"] = self.need_pad
-        state["use_unk"] = self.use_unk
-        state["element2id_dict"] = self.element2id_dict
-        state["id2element_dict"] = self.id2element_dict
-        state["next_id"] = self.next_id
+        state = {
+            "method": self.method,
+            "need_pad": self.need_pad,
+            "use_unk": self.use_unk,
+            "element2id_dict": self.element2id_dict,
+            "id2element_dict": self.id2element_dict,
+            "next_id": self.next_id
+        }
         return state
 
     def __setstate__(self, state):

--- a/tests/forte/data/extractor/base_extractor_test.py
+++ b/tests/forte/data/extractor/base_extractor_test.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import unittest
-
+import pickle as pkl
 from ft.onto.base_ontology import Token
 from forte.data.extractor.base_extractor import BaseExtractor
 
@@ -28,12 +28,12 @@ class BaseExtractorTest(unittest.TestCase):
 
         extractor = BaseExtractor(config)
 
-        new_extractor = BaseExtractor.from_state(extractor.state)
+        new_extractor = pkl.loads(pkl.dumps(extractor))
 
         # Check state and from state
         self.assertEqual(extractor.config.entry_type, new_extractor.config.entry_type)
         self.assertEqual(extractor.config.entry_type, Token)
-        self.assertEqual(extractor.vocab.state, new_extractor.vocab.state)
+        self.assertNotEqual(new_extractor.vocab, None)
 
         # Check entry_type
         self.assertEqual(extractor.entry_type, Token)

--- a/tests/forte/data/vocabulary_test.py
+++ b/tests/forte/data/vocabulary_test.py
@@ -26,7 +26,7 @@ class VocabularyTest(unittest.TestCase):
                 idx = i
         return idx
 
-    def test_indexing_vocab(self):
+    def test_vocabulary(self):
         methods = ["indexing", "one-hot"]
         flags = [True, False]
         for method, need_pad, use_unk in product(methods, flags, flags):

--- a/tests/forte/data/vocabulary_test.py
+++ b/tests/forte/data/vocabulary_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+import pickle as pkl
 from itertools import product
 from forte.data.vocabulary import Vocabulary
 
@@ -95,8 +96,7 @@ class VocabularyTest(unittest.TestCase):
                 self.assertEqual(saved_len, len(vocab))
 
             # Check state
-            new_vocab = Vocabulary.from_state(vocab.state)
-            self.assertEqual(dir(vocab), dir(new_vocab))
+            new_vocab = pkl.loads(pkl.dumps(vocab))
             self.assertEqual(vocab.method, new_vocab.method)
             self.assertEqual(vocab.need_pad, new_vocab.need_pad)
             self.assertEqual(vocab.use_unk, new_vocab.use_unk)


### PR DESCRIPTION
### Description of changes
use `__getstate__` and `__setstate__` to save vocabulary instead of `state` and `from_state` function.

### Possible influences of this PR.
The way to save vocabulary will be changed. After this PR, users can use pickle to save vocabulary directly.

### Test Conducted
Pickle load and dump is tested.
