### PR TITLE
Fixing SRL hparam errors

### DIFF
--- a/forte/models/srl/model.py
+++ b/forte/models/srl/model.py
@@ -141,7 +141,7 @@ class LabeledSpanGraphNetwork(tx.ModuleBase):
             })
 
     @staticmethod
-    def default_configs() -> Dict[str, Any]:
+    def default_hparams() -> Dict[str, Any]:
         return {
             "filter_widths": [3, 4, 5],
             "filter_size": 50,
@@ -384,7 +384,7 @@ class LabeledSpanGraphNetwork(tx.ModuleBase):
         cache_inputs = [states, states, head_attn_cache, span_length_embed]
         pred_indices = self._arange(max_len).expand(batch_size, -1)
         with self.argument_mlp.cache_results(cache_inputs), \
-             self.predicate_mlp.cache_results([states]):
+                self.predicate_mlp.cache_results([states]):
             # arg_scores: (batch_size, max_num_spans)
             arg_scores = self.argument_mlp(
                 [start_ids, end_ids, head_attn_index, span_length]).squeeze(-1)

--- a/forte/models/srl/model_utils.py
+++ b/forte/models/srl/model_utils.py
@@ -122,7 +122,7 @@ class CustomBiLSTM(tx.modules.EncoderBase):
         self.dropout = nn.Dropout(self._hparams.dropout)
 
     @staticmethod
-    def default_configs() -> Dict[str, Any]:
+    def default_hparams() -> Dict[str, Any]:
         return {
             "input_dim": 200,
             "hidden_dim": 200,
@@ -167,7 +167,7 @@ class CharCNN(tx.ModuleBase):
         self._max_filter_width = max(self._hparams.filter_widths)
 
     @staticmethod
-    def default_configs() -> Dict[str, Any]:
+    def default_hparams() -> Dict[str, Any]:
         return {
             "char_embed_size": 8,
             "filter_widths": [3, 4, 5],
@@ -303,7 +303,7 @@ class MLP(tx.ModuleBase):
         self.layers = nn.Sequential(*layers)
 
     @staticmethod
-    def default_configs() -> Dict[str, Any]:
+    def default_hparams() -> Dict[str, Any]:
         return {
             "input_size": 300,
             "num_layers": 2,
@@ -330,7 +330,7 @@ class ConcatInputMLP(tx.ModuleBase):
         self.mlp = MLP(mlp_hparams)
 
     @staticmethod
-    def default_configs() -> Dict[str, Any]:
+    def default_hparams() -> Dict[str, Any]:
         return {
             "input_sizes": [150, 150],
             "num_layers": 2,

--- a/forte/processors/srl_predictor.py
+++ b/forte/processors/srl_predictor.py
@@ -72,7 +72,7 @@ class SRLPredictor(FixedSizeBatchProcessor):
             os.path.join(model_dir, "embeddings/word_vocab.english.txt"))
         self.char_vocab = tx.data.Vocab(
             os.path.join(model_dir, "embeddings/char_vocab.english.txt"))
-        model_hparams = LabeledSpanGraphNetwork.default_configs()
+        model_hparams = LabeledSpanGraphNetwork.default_hparams()
         model_hparams["context_embeddings"]["path"] = os.path.join(
             model_dir, model_hparams["context_embeddings"]["path"])
         model_hparams["head_embeddings"]["path"] = os.path.join(
@@ -115,11 +115,12 @@ class SRLPredictor(FixedSizeBatchProcessor):
             for pred_idx, pred_args in srl_spans.items():
                 begin, end = word_spans[pred_idx]
                 # TODO cannot create annotation here.
-                pred_span = Span(begin, end)
+                # Need to convert from Numpy numbers to int.
+                pred_span = Span(begin.item(), end.item())
                 arguments = []
                 for arg in pred_args:
-                    begin = word_spans[arg.start][0]
-                    end = word_spans[arg.end][1]
+                    begin = word_spans[arg.start][0].item()
+                    end = word_spans[arg.end][1].item()
                     arg_annotation = Span(begin, end)
                     arguments.append((arg_annotation, arg.label))
                 predictions.append((pred_span, arguments))


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/364. 

### Description of changes
There are a few changes in the API causing the SRL example to fail:
1. The `Span` object now only takes native Python int, so we need to convert before creating Span now.
2. Forte's default parameter function is named `default_config` but the Texar one is named `default_hparam`. For any models that extend the texar module, we should correctly use `default_hparam`, otherwise the system will not find the correct config. 

### Possible influences of this PR.
Code changes are only inside the SRL model.

### Test Conducted
No new tests are not added yet.
