### PR TITLE
Fix doc runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 -----------------
 
-[![Build Status](https://travis-ci.org/asyml/forte.svg?branch=master)](https://travis-ci.org/asyml/forte)
+[![Build Status](https://github.com/asyml/forte/actions/workflows/main.yml/badge.svg)](https://github.com/asyml/forte/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/asyml/forte/branch/master/graph/badge.svg)](https://codecov.io/gh/asyml/forte)
 [![Documentation Status](https://readthedocs.org/projects/asyml-forte/badge/?version=latest)](https://asyml-forte.readthedocs.io/en/latest/?badge=latest)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/asyml/forte/blob/master/LICENSE)
@@ -14,7 +14,7 @@
 **Forte** is a toolkit for building Natural Language Processing pipelines, featuring cross-task 
 interaction, adaptable data-model interfaces and composable pipeline. 
 Forte was originally developed in CMU and is actively contributed by [Petuum](https://petuum.com/) 
-in collaboration with other institutes.
+in collaboration with other institutes.~~~~
 This project is part of the [CASL Open Source](http://casl-project.ai/) family.
 
 Forte provides a platform to assemble

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,16 @@
-# Addtional requirements for docs.
-
 sphinx-rtd-theme >= 0.5.0
-sphinxcontrib-spelling
 Pygments >= 2.1.1
+funcsigs~=1.0.2
 recommonmark
+mypy_extensions~=0.4.1
+sphinxcontrib-spelling
+
+pyyaml==5.4
+jsonpickle==1.4
+sortedcontainers==2.1.0
+texar-pytorch>=0.1.1
+typing>=3.7.4; python_version < '3.5'
+typing-inspect>=0.6.0
 
 # PyTorch installation for ReadTheDocs
 https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
@@ -13,6 +20,11 @@ faiss-cpu>=1.6.1
 
 # elasticsearch
 elasticsearch==7.5.1
+
+# code generation
+typed_astunparse~=2.1.4
+typed_ast~=1.4.0
+jsonschema==3.0.2
 
 # Transformers
 transformers>=3.1


### PR DESCRIPTION
Doc requirements need to be retained to make it run on read-the-docs

### Description of changes
Some dependencies are removed from docs/requirements.txt, but that will make read-the-doc fail because the site only reads doc/requirements.txt. This PR revert back that change.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
