### PR TITLE
fix instance check in ElasticSearchProcessor

### DIFF
--- a/forte/processors/ir/elastic_search_processor.py
+++ b/forte/processors/ir/elastic_search_processor.py
@@ -69,7 +69,7 @@ class ElasticSearchProcessor(MultiPackProcessor):
         first_query: Query = query_pack.get_single(Query)  # type: ignore
         # pylint: disable=isinstance-second-argument-not-valid-type
         # TODO: until fix: https://github.com/PyCQA/pylint/issues/3507
-        if not isinstance(first_query, Dict):
+        if not isinstance(first_query.value, Dict):
             raise ValueError(
                 "The query to the elastic indexer need to be a dictionary.")
         results = self.index.search(first_query.value)


### PR DESCRIPTION
This PR fixes [#402]. 

### Description of changes
Check query.value instead of query which is not a Dict.

### Possible influences of this PR.
None

### Test Conducted
Successfully ran pipeline connecting ElasticSearchQueryCreator and ElasticSearchProcessor

Closes #402 