### PR TITLE
More config options for AllenNLPProcessor

### DIFF
--- a/forte/processors/ir/elastic_search_processor.py
+++ b/forte/processors/ir/elastic_search_processor.py
@@ -69,7 +69,7 @@ class ElasticSearchProcessor(MultiPackProcessor):
         first_query: Query = query_pack.get_single(Query)  # type: ignore
         # pylint: disable=isinstance-second-argument-not-valid-type
         # TODO: until fix: https://github.com/PyCQA/pylint/issues/3507
-        if not isinstance(first_query, Dict):
+        if not isinstance(first_query.value, Dict):
             raise ValueError(
                 "The query to the elastic indexer need to be a dictionary.")
         results = self.index.search(first_query.value)


### PR DESCRIPTION
### Description of changes
Adding two types for config options in AllenNLPProcessor
1. Model URL's.
2. Use gpu and basic control of gpu assignment (for each model)

### Possible influences of this PR.
N/A

### Test Conducted
Tested against a pipeline using AllenNLPProcessor.
