### PR TITLE
Throw exceptions when the ontology definition contains invalid identifiers

### DIFF
--- a/forte/data/ontology/code_generation_exceptions.py
+++ b/forte/data/ontology/code_generation_exceptions.py
@@ -1,58 +1,88 @@
+# Copyright 2019 The Forte Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+    Exception classes for ontology code generation.
+"""
+
+
 class OntologyGenerationWarning(UserWarning):
+    """General warning for ontology generation."""
     pass
 
 
 class DirectoryAlreadyPresentWarning(OntologyGenerationWarning):
+    """The directory that the code will be written to already exists."""
     pass
 
 
 class DuplicateEntriesWarning(OntologyGenerationWarning):
+    """The entry is defined multiple times."""
     pass
 
 
 class DuplicatedAttributesWarning(OntologyGenerationWarning):
+    """The attribute is defined multiple times."""
     pass
 
 
 class OntologySpecError(ValueError):
+    """General error related to ontology specification."""
     pass
 
 
 class OntologySpecValidationError(OntologySpecError):
+    """Error thrown during validating the ontology specification."""
     pass
 
 
 class OntologySourceNotFoundException(OntologySpecError):
+    """Raise when the import source specification cannot be found."""
     pass
 
 
 class OntologyAlreadyGeneratedException(OntologySpecError):
+    """Raise when generating the same ontology again, which is considered
+    to be a cyclic or duplicated declaration."""
     pass
 
 
 class ParentEntryNotDeclaredException(OntologySpecError):
+    """Raise when the entry's parent entry is not previously defined."""
     pass
 
 
 class ParentEntryNotSupportedException(OntologySpecError):
+    """Raise when the entry uses a not allowed parent entry."""
     pass
 
 
 class TypeNotDeclaredException(OntologySpecError):
-    pass
-
-
-class NoDefaultClassAttributeException(OntologySpecError):
+    """Raise when the entry uses an attribute which is previously not defined.
+    """
     pass
 
 
 class UnsupportedTypeException(OntologySpecError):
+    """Raise when the ontology generator do not support such type structure."""
     pass
 
 
-class InvalidIdentifierException(ValueError):
+class InvalidIdentifierException(OntologySpecValidationError):
+    """Raise when the ontology contains illegal identifier."""
     pass
 
 
 class CodeGenerationException(BaseException):
+    """General errors during ontology generation."""
     pass

--- a/forte/data/ontology/ontology_code_generator.py
+++ b/forte/data/ontology/ontology_code_generator.py
@@ -119,6 +119,12 @@ def validate_entry(entry_name: str, sorted_packages: List[str],
 
     entry_splits = entry_name.split('.')
 
+    for e in entry_splits:
+        if not e.isidentifier():
+            raise InvalidIdentifierException(
+                f"The entry name segment {e} is not a valid python identifier."
+            )
+
     if len(entry_splits) < 3:
         raise InvalidIdentifierException(
             f"We currently require each entry to contains at least 3 levels, "
@@ -643,6 +649,13 @@ class OntologyCodeGenerator:
 
             # Adding entry attributes to the allowed types for validation.
             for property_name in properties:
+                # Check if the name is allowed.
+                if not property_name.isidentifier():
+                    raise InvalidIdentifierException(
+                        f"The property name: {property_name} is not a valid "
+                        f"python identifier."
+                    )
+
                 if property_name in self.allowed_types_tree[en.class_name]:
                     warnings.warn(
                         f"Attribute type for the entry {en.class_name} "

--- a/forte/ontology_specs/race_qa.json
+++ b/forte/ontology_specs/race_qa.json
@@ -1,7 +1,7 @@
 {
   "name": "race_multi_choice_qa_ontology",
   "imports": [
-    "forte/ontology_specs/base_ontology.json"
+    "base_ontology.json"
   ],
   "definitions": [
     {

--- a/forte/ontology_specs/wikipedia.json
+++ b/forte/ontology_specs/wikipedia.json
@@ -1,7 +1,7 @@
 {
   "name": "wikipedia",
   "imports": [
-    "forte/ontology_specs/base_ontology.json"
+    "base_ontology.json"
   ],
   "definitions": [
     {

--- a/tests/forte/data/ontology/ontology_code_generator_test.py
+++ b/tests/forte/data/ontology/ontology_code_generator_test.py
@@ -29,7 +29,8 @@ from forte.data.ontology import utils
 from forte.data.ontology.code_generation_exceptions import (
     DuplicatedAttributesWarning, DuplicateEntriesWarning,
     OntologySourceNotFoundException, TypeNotDeclaredException,
-    UnsupportedTypeException, ParentEntryNotSupportedException)
+    UnsupportedTypeException, ParentEntryNotSupportedException,
+    InvalidIdentifierException)
 from forte.data.ontology.code_generation_objects import ImportManager
 from forte.data.ontology.ontology_code_generator import OntologyCodeGenerator
 
@@ -148,7 +149,10 @@ class GenerateOntologyTest(unittest.TestCase):
           (False, 'test_invalid_attribute.json', TypeNotDeclaredException),
           (False, 'test_nested_item_type.json', UnsupportedTypeException),
           (False, 'test_no_item_type.json', TypeNotDeclaredException),
-          (False, 'test_unknown_item_type.json', TypeNotDeclaredException))
+          (False, 'test_unknown_item_type.json', TypeNotDeclaredException),
+          (False, 'test_invalid_entry_name.json', InvalidIdentifierException),
+          (False, 'test_invalid_attr_name.json', InvalidIdentifierException),
+          )
     def test_warnings_errors(self, value):
         expected_warning, file, msg_type = value
         temp_dir = tempfile.mkdtemp()

--- a/tests/forte/data/ontology/test_specs/test_invalid_attr_name.json
+++ b/tests/forte/data/ontology/test_specs/test_invalid_attr_name.json
@@ -1,0 +1,15 @@
+{
+  "name": "test_ontology",
+  "definitions": [
+    {
+      "entry_name": "ft.onto.test_ontology.Token",
+      "parent_entry": "forte.data.ontology.top.Annotation",
+      "attributes": [
+        {
+          "name": "invalid attribute name",
+          "type": "str"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/forte/data/ontology/test_specs/test_invalid_entry_name.json
+++ b/tests/forte/data/ontology/test_specs/test_invalid_entry_name.json
@@ -1,0 +1,15 @@
+{
+  "name": "test_ontology",
+  "definitions": [
+    {
+      "entry_name": "ft.onto.not allowed name.Token",
+      "parent_entry": "forte.data.ontology.top.Annotation",
+      "attributes": [
+        {
+          "name": "pos",
+          "type": "str"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/406 

### Description of changes
Check for the names in the entry name and attribute to see if they are identifiers. Exceptions will be thrown if not.

### Possible influences of this PR.
N/A

### Test Conducted
Added two test cases where the identifiers are wrong, and throw relevant exceptions.