### PR TITLE
Do not initialize the same processor instance multiple times

### DIFF
--- a/forte/data/base_reader.py
+++ b/forte/data/base_reader.py
@@ -19,7 +19,7 @@ import os
 from time import time
 from abc import abstractmethod, ABC
 from pathlib import Path
-from typing import Any, Iterator, Optional, Union, List, Dict, Set
+from typing import Any, Iterator, Optional, Union, List, Dict, Set, TypeVar
 
 from forte.common.configuration import Config
 from forte.common.exception import ProcessExecutionException
@@ -35,6 +35,7 @@ __all__ = [
     "BaseReader",
     "PackReader",
     'MultiPackReader',
+    'ReaderType',
 ]
 
 logger = logging.getLogger(__name__)
@@ -379,3 +380,6 @@ class MultiPackReader(BaseReader[MultiPack], ABC):
     @property
     def pack_type(self):
         return MultiPack
+
+
+ReaderType = TypeVar('ReaderType', bound=BaseReader)

--- a/forte/data/base_reader.py
+++ b/forte/data/base_reader.py
@@ -19,7 +19,7 @@ import os
 from time import time
 from abc import abstractmethod, ABC
 from pathlib import Path
-from typing import Any, Iterator, Optional, Union, List, Dict, Set, TypeVar
+from typing import Any, Iterator, Optional, Union, List, Dict, Set
 
 from forte.common.configuration import Config
 from forte.common.exception import ProcessExecutionException
@@ -35,7 +35,6 @@ __all__ = [
     "BaseReader",
     "PackReader",
     'MultiPackReader',
-    'ReaderType',
 ]
 
 logger = logging.getLogger(__name__)
@@ -380,6 +379,3 @@ class MultiPackReader(BaseReader[MultiPack], ABC):
     @property
     def pack_type(self):
         return MultiPack
-
-
-ReaderType = TypeVar('ReaderType', bound=BaseReader)

--- a/forte/data/data_pack.py
+++ b/forte/data/data_pack.py
@@ -169,7 +169,7 @@ class DataPack(BasePack[Entry, Link, Group]):
         An iterator of all annotations in this data pack.
 
         Returns: Iterator of all annotations, of
-          type :class:"~forte.data.ontology.top.Annotation".
+        type :class:`~forte.data.ontology.top.Annotation`.
 
         """
         yield from self.annotations
@@ -190,7 +190,7 @@ class DataPack(BasePack[Entry, Link, Group]):
         An iterator of all links in this data pack.
 
         Returns: Iterator of all links, of
-          type :class:"~forte.data.ontology.top.Link".
+        type :class:`~forte.data.ontology.top.Link`.
 
         """
         yield from self.links
@@ -211,7 +211,7 @@ class DataPack(BasePack[Entry, Link, Group]):
         An iterator of all groups in this data pack.
 
         Returns: Iterator of all groups, of
-          type :class:"~forte.data.ontology.top.Group".
+        type :class:`~forte.data.ontology.top.Group`.
 
         """
         yield from self.groups

--- a/forte/data/selector.py
+++ b/forte/data/selector.py
@@ -81,8 +81,8 @@ class NameMatchSelector(SinglePackSelector):
                 yield pack
 
         if matches == 0:
-            raise ValueError(f"pack name {self.select_name}"
-                             f"not in the MultiPack")
+            raise ValueError(f"Pack name {self.select_name}"
+                             f" not in the MultiPack")
 
 
 class RegexNameMatchSelector(SinglePackSelector):

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -18,7 +18,6 @@ Base class for Pipeline module.
 import itertools
 import logging
 from time import time
-from collections import defaultdict
 from typing import Any, Dict, Generic, Iterator, List, Optional, Union, Tuple, \
     Deque, Set
 
@@ -505,7 +504,7 @@ class Pipeline(Generic[PackType]):
         if self._enable_profiling:
             out_header: str = "Pipeline Time Profile\n"
             out_reader: str = f"- Reader: {self.reader.component_name}, " + \
-                f"{self.reader.time_profile} s\n"
+                              f"{self.reader.time_profile} s\n"
             out_processor: str = '\n'.join([
                 f"- Component [{i}]: {self.components[i].name}, {t} s"
                 for i, t in enumerate(self._profiler)])

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -20,7 +20,7 @@ import logging
 from time import time
 from collections import defaultdict
 from typing import Any, Dict, Generic, Iterator, List, Optional, Union, Tuple, \
-    Deque, DefaultDict, Set
+    Deque, Set
 
 import yaml
 

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -248,9 +248,9 @@ class Pipeline(Generic[PackType]):
 
     def initialize_processors(self):
         """
-        This function will initialize all the components in ths pipeline, except
-        the reader. The components are initialized in a FIFO manner based on
-        the order of insertion,
+        This function will initialize all the components in this pipeline,
+        except the reader. The components are initialized in a FIFO manner
+        based on the order of insertion,
 
         During initialization, the component will be configured based on its
         corresponding configuration. However, if the component is already

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -20,7 +20,7 @@ import logging
 from time import time
 from collections import defaultdict
 from typing import Any, Dict, Generic, Iterator, List, Optional, Union, Tuple, \
-    Deque
+    Deque, DefaultDict
 
 import yaml
 
@@ -106,8 +106,8 @@ class Pipeline(Generic[PackType]):
         self._selectors: List[Selector] = []
         self._configs: List[Optional[Config]] = []
 
-        self.__hashed_components: \
-            defaultdict[int, List[int]] = defaultdict(list)
+        self.__hashed_components: DefaultDict[
+            int, List[int]] = defaultdict(list)
 
         # Will initialize at `initialize` because the processors length is
         # unknown.
@@ -130,7 +130,7 @@ class Pipeline(Generic[PackType]):
         self._check_type_consistency: bool = False
 
         # Create one copy of the dummy selector to reduce class creation.
-        self.__default_selector = DummySelector()
+        self.__default_selector: Selector = DummySelector()
 
         # needed for time profiling of pipeline
         self._enable_profiling: bool = False

--- a/forte/pipeline_component.py
+++ b/forte/pipeline_component.py
@@ -90,7 +90,7 @@ class PipelineComponent(Generic[PackType]):
         self.configs = configs
         self.__is_initialized = True
 
-    def reset_flag(self):
+    def reset_flags(self):
         """
         Reset the flags related to this component. This will be called first
         when doing initialization.

--- a/forte/pipeline_component.py
+++ b/forte/pipeline_component.py
@@ -90,6 +90,13 @@ class PipelineComponent(Generic[PackType]):
         self.configs = configs
         self.__is_initialized = True
 
+    def reset_flag(self):
+        """
+        Reset the flags related to this component. This will be called first
+        when doing initialization.
+        """
+        self.__is_initialized = False
+
     @property
     def is_initialized(self) -> bool:
         return self.__is_initialized
@@ -135,7 +142,7 @@ class PipelineComponent(Generic[PackType]):
             cls, configs: Optional[Union[Config, Dict[str, Any]]]) -> Config:
         """
         Create the component configuration for this class, by merging the
-        provided config with the ``default_config``.
+        provided config with the ``default_configs()``.
 
         The following config conventions are expected:
           - The top level key can be a special `config_path`.

--- a/forte/pipeline_component.py
+++ b/forte/pipeline_component.py
@@ -28,10 +28,26 @@ from forte.utils import get_full_module_name
 
 
 class PipelineComponent(Generic[PackType]):
+    """
+    The base class for all pipeline component. A pipeline component represents
+    one node in the pipeline, and would perform certain action on the data
+    pack. All pipeline components should extend this class.
+
+    Attributes:
+        resources: The resources that can be used by this component, the
+          `resources` object is a shared object across the whole pipeline.
+        configs: The configuration of this component, will be built by the
+          pipeline based on the `default_configs()` and the configs provided
+          by the users.
+    """
+
     def __init__(self):
         self.resources: Resources = Resources()
         self.configs: Config = Config({}, {})
-        self._check_type_consistency = False
+        # Determine whether to check the consistencies between components.
+        self._check_type_consistency: bool = False
+        # The flag indicating whether the component is initialized.
+        self.__is_initialized: bool = False
 
     def enforce_consistency(self, enforce: bool = True):
         r"""This function determines whether the pipeline will enforce
@@ -72,6 +88,11 @@ class PipelineComponent(Generic[PackType]):
         """
         self.resources = resources
         self.configs = configs
+        self.__is_initialized = True
+
+    @property
+    def is_initialized(self) -> bool:
+        return self.__is_initialized
 
     def add_entry(self, pack: BasePack, entry: Entry):
         """
@@ -98,6 +119,7 @@ class PipelineComponent(Generic[PackType]):
         pass
 
     def finish(self, resource: Resources):
+        # pylint: disable = unused-argument
         r"""The pipeline will call this function at the end of the pipeline to
         notify all the components. The user can implement this function to
         release resources used by this component. The component can also add
@@ -106,7 +128,7 @@ class PipelineComponent(Generic[PackType]):
         Args:
             resource (Resources): A global resource registry.
         """
-        pass
+        self.__is_initialized = False
 
     @classmethod
     def make_configs(

--- a/tests/forte/pipeline_test.py
+++ b/tests/forte/pipeline_test.py
@@ -44,7 +44,7 @@ from forte.processors.base.batch_processor import Predictor, BatchProcessor
 from forte.train_preprocessor import TrainPreprocessor
 from forte.utils import get_full_module_name
 from ft.onto.base_ontology import Token, Sentence, EntityMention, RelationLink
-from forte.common import ProcessExecutionException
+from forte.common import ProcessExecutionException, ProcessorConfigError
 
 data_samples_root = os.path.abspath(os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
@@ -1074,10 +1074,14 @@ class RecordCheckPipelineTest(unittest.TestCase):
         dummy = DummyPackProcessor()
         nlp.add(dummy, config={"test": "dummy1"},
                 selector=NameMatchSelector("default"))
-        # This will not change config because the processor is initialized.
-        #  but the selector should work.
-        nlp.add(dummy, config={"test": "dummy2"},
-                selector=NameMatchSelector("copy"))
+
+        # This will not add the component successfully because the processor is
+        # initialized.
+        with self.assertRaises(ProcessorConfigError):
+            nlp.add(dummy, config={"test": "dummy2"})
+
+        # This will add the component, with a different selector
+        nlp.add(dummy, selector=NameMatchSelector("copy"))
         nlp.initialize()
 
         # Check that the two processors have the same name.


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/410. 

### Description of changes
1. Add a flag for each `PipelineComponent` marking the initialization status.
2. When the pipeline is initializing, it will check whether the flag is True. It will skip initializing the processor if the flag is True.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
A reuse-processor test is added. The testing processor will record the number of times it gets initialized. And the number should be 1. 
