### PR TITLE
Fix setup.py including example and test folders.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='Apache License Version 2.0',
-    packages=setuptools.find_packages(exclude=["scripts", "examples", "tests"]),
+    packages=setuptools.find_packages(
+        exclude=["scripts*", "examples*", "tests*"]),
     include_package_data=True,
     platforms='any',
 


### PR DESCRIPTION
This PR fixes the problem where examples, tests and scripts are included in the published package.

### Description of changes
Change the exclude in `find_packages` command slightly to include a `*`, which now successfully exclude the folders.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
