### PR TITLE
Add service validation

### DIFF
--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -469,7 +469,7 @@ class Pipeline(Generic[PackType]):
 
         # Check record types and attributes of each pipeline component
         if self._do_init_type_check:
-            current_records = {}
+            current_records: Dict[str, Set[str]] = {}
             self._reader.record(current_records)
             for component in self.components:
                 record_types_and_attributes_check(

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -472,15 +472,13 @@ class Pipeline(Generic[PackType]):
             current_records: Dict[str, Set[str]] = {}
             self._reader.record(current_records)
             for component in self.components:
-                if not (
-                    hasattr(component, "expected_types_and_attributes")
-                    and hasattr(component, "record")
-                ):
-                    continue
-                record_types_and_attributes_check(
-                    component.expected_types_and_attributes(), current_records  # type: ignore
-                )
-                component.record(current_records)  # type: ignore
+                if hasattr(component, "expected_types_and_attributes"):
+                    record_types_and_attributes_check(
+                        component.expected_types_and_attributes(),  # type: ignore
+                        current_records,
+                    )
+                if hasattr(component, "record"):
+                    component.record(current_records)  # type: ignore
 
         return self
 

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -472,10 +472,15 @@ class Pipeline(Generic[PackType]):
             current_records: Dict[str, Set[str]] = {}
             self._reader.record(current_records)
             for component in self.components:
+                if not (
+                    hasattr(component, "expected_types_and_attributes")
+                    and hasattr(component, "record")
+                ):
+                    continue
                 record_types_and_attributes_check(
-                    component.expected_types_and_attributes(), current_records
+                    component.expected_types_and_attributes(), current_records  # type: ignore
                 )
-                component.record(current_records)
+                component.record(current_records)  # type: ignore
 
         return self
 

--- a/forte/processors/misc/remote_processor.py
+++ b/forte/processors/misc/remote_processor.py
@@ -68,8 +68,10 @@ class RemoteProcessor(PackProcessor):
         response = self._requests.get(self.configs.url)
         if response.status_code != 200 or response.json()["status"] != "OK":
             raise ProcessorConfigError(
-                f"{response.status_code} {response.reason}: "
-                "Remote service not started or invalid endpoint configs."
+                f"{response.status_code} {response.reason}: Please double "
+                "check your endpoint URL configuration and make sure that the "
+                f"remote service at {self.configs.url} is a valid pipeline "
+                "service that is up and running."
             )
         service_name: str = response.json()["service_name"]
         input_format: str = response.json()["input_format"]
@@ -100,7 +102,9 @@ class RemoteProcessor(PackProcessor):
             if response.status_code != 200 or response.json()["status"] != "OK":
                 raise ProcessorConfigError(
                     f"{response.status_code} {response.reason}: "
-                    "Fail to fetch records from remote service."
+                    "Fail to fetch records from remote service. Please make "
+                    f"sure that the remote service at {self.configs.url} is "
+                    "a valid pipeline service that is up and running."
                 )
             self._records = response.json()["records"]
 
@@ -128,7 +132,9 @@ class RemoteProcessor(PackProcessor):
         if response.status_code != 200 or response.json()["status"] != "OK":
             raise Exception(
                 f"{response.status_code} {response.reason}: "
-                "Invalid post request."
+                "Invalid post request to process input pack. Please make "
+                f"sure that the remote service at {self.configs.url} is "
+                "a valid pipeline service that is up and running."
             )
         result = response.json()["result"]
         input_pack.update(DataPack.deserialize(result))

--- a/forte/processors/misc/remote_processor.py
+++ b/forte/processors/misc/remote_processor.py
@@ -117,7 +117,10 @@ class RemoteProcessor(PackProcessor):
             input_pack: The input datapack.
         """
         super().check_record(input_pack)
-        if self._validation.do_init_type_check:
+        if (
+            self._validation.do_init_type_check
+            and self._validation.expected_records is not None
+        ):
             # Validate the output records
             record_types_and_attributes_check(
                 self._validation.expected_records.todict(), self._records

--- a/tests/forte/processors/remote_processor_test.py
+++ b/tests/forte/processors/remote_processor_test.py
@@ -33,6 +33,16 @@ from forte.data.common_entry_utils import create_utterance, get_last_utterance
 from ft.onto.base_ontology import Utterance
 
 
+TEST_RECORDS_1 = {
+    "Token": {"1", "2"},
+    "Document": {"2"},
+}
+TEST_RECORDS_2 = {
+    "ft.onto.example_import_ontology.Token": {"pos", "lemma"},
+    "Sentence": {"1", "2", "3"},
+}
+
+
 class UserSimulator(PackProcessor):
     """
     A simulated processor that will generate utterance based on the config.
@@ -41,18 +51,35 @@ class UserSimulator(PackProcessor):
     def _process(self, input_pack: DataPack):
         create_utterance(input_pack, self.configs.user_input, "user")
 
-    def record(self, record_meta: Dict[str, Set[str]]):
-        """
-        Add records to test validation in RemoteProcessor
-        """
-        record_meta["Token"] = {"1", "2"}
-        record_meta["Document"] = {"2"}
-
     @classmethod
     def default_configs(cls):
         config = super().default_configs()
         config["user_input"] = ""
         return config
+
+
+class DummyProcessor(PackProcessor):
+    """
+    A dummpy Processor to check the expected/output records from the remote
+    pipeline.
+    """
+
+    def __init__(
+        self,
+        expected_records: Dict[str, Set[str]] = {},
+        output_records: Dict[str, Set[str]] = {},
+    ):
+        self._expected_records: Dict[str, Set[str]] = expected_records
+        self._output_records: Dict[str, Set[str]] = output_records
+
+    def _process(self, input_pack: DataPack):
+        pass
+
+    def expected_types_and_attributes(self):
+        return self._expected_records
+
+    def record(self, record_meta: Dict[str, Set[str]]):
+        record_meta.update(self._output_records)
 
 
 @ddt
@@ -114,7 +141,9 @@ class TestRemoteProcessor(unittest.TestCase):
         # Build service pipeline
         serve_pl: Pipeline[DataPack] = Pipeline[DataPack]()
         serve_pl.set_reader(RawDataDeserializeReader())
+        serve_pl.add(DummyProcessor(expected_records=TEST_RECORDS_1))
         serve_pl.add(UserSimulator(), config={"user_input": i_str})
+        serve_pl.add(DummyProcessor(output_records=TEST_RECORDS_2))
         serve_pl.add(ElizaProcessor())
         serve_pl.initialize()
 
@@ -127,8 +156,11 @@ class TestRemoteProcessor(unittest.TestCase):
         )
 
         # Build test pipeline
-        test_pl: Pipeline[DataPack] = Pipeline[DataPack]()
+        test_pl: Pipeline[DataPack] = Pipeline[DataPack](
+            do_init_type_check=True
+        )
         test_pl.set_reader(StringReader())
+        test_pl.add(DummyProcessor(output_records=TEST_RECORDS_1))
         test_pl.add(
             remote_processor,
             config={
@@ -136,13 +168,10 @@ class TestRemoteProcessor(unittest.TestCase):
                     "do_init_type_check": True,
                     "input_format": input_format,
                     "expected_name": service_name,
-                    "expected_records": {
-                        "Token": {"1", "2"},
-                        "Document": {"2"},
-                    },
                 }
             },
         )
+        test_pl.add(DummyProcessor(expected_records=TEST_RECORDS_2))
         test_pl.initialize()
 
         # Verify output

--- a/tests/forte/processors/remote_processor_test.py
+++ b/tests/forte/processors/remote_processor_test.py
@@ -109,6 +109,7 @@ class TestRemoteProcessor(unittest.TestCase):
         """
         i_str, o_str = input_output_pair
         service_name: str = "test_service_name"
+        input_format: str = "DataPack"
 
         # Build service pipeline
         serve_pl: Pipeline[DataPack] = Pipeline[DataPack]()
@@ -120,7 +121,9 @@ class TestRemoteProcessor(unittest.TestCase):
         # Configure RemoteProcessor into test mode
         remote_processor: RemoteProcessor = RemoteProcessor()
         remote_processor.set_test_mode(
-            serve_pl._remote_service_app(name=service_name)
+            serve_pl._remote_service_app(
+                service_name=service_name, input_format=input_format
+            )
         )
 
         # Build test pipeline
@@ -129,11 +132,15 @@ class TestRemoteProcessor(unittest.TestCase):
         test_pl.add(
             remote_processor,
             config={
-                "do_validation": True,
-                "expected_name": service_name,
-                "expected_records": json.dumps(
-                    {"Token": ["1", "2"], "Document": ["2"]}
-                ),
+                "validation": {
+                    "do_init_type_check": True,
+                    "input_format": input_format,
+                    "expected_name": service_name,
+                    "expected_records": {
+                        "Token": {"1", "2"},
+                        "Document": {"2"},
+                    },
+                }
             },
         )
         test_pl.initialize()


### PR DESCRIPTION
This PR is an update to #476. 

### Description of changes
- pipeline.py
    - User can assign a name to pipeline service by calling `Pipeline().serve(name="name")` or `forte.serve(pl_path="pl_path", name="name")` 
    - Add a new page `\records` in FastAPI app which will return a collection of records from all components in the pipeline.
- remote_processor.py
    - User can now configure `RemoteProcessor` to validate the remote service by adding `do_validation`, `expected_name` and `expected_records` field.
```python
pipeline.add(
    RemoteProcessor,
    config={
        "do_validation": True,
        "expected_name": service_name,
        "expected_records": json.dumps(
            {"Token": ["1", "2"], "Document": ["2"]}
        ),
    },
)
```
- remote_processor_test.py
    - Add test case for service name and records checking. 

### Possible influences of this PR.

### Test Conducted
`remote_processor_test.py` is updated to test validation.
