### PR TITLE
Use fixed ontology to test StaveProcessor

### DIFF
--- a/forte/processors/stave/stave_processor.py
+++ b/forte/processors/stave/stave_processor.py
@@ -191,6 +191,13 @@ class StaveProcessor(PackProcessor):
                 "right": "default-attribute",
                 "center-bottom": "disable",
             },
+            "remoteConfigs": {
+                "pipelineUrl": "",
+                "doValidation": False,
+                "expectedName": "",
+                "inputFormat": "string",
+                "expectedRecords": {},
+            },
         }
 
         # Create legend configs

--- a/tests/forte/data/ontology/test_specs/test_project_configuration.json
+++ b/tests/forte/data/ontology/test_specs/test_project_configuration.json
@@ -17,6 +17,11 @@
             "is_shown": true,
             "attributes": {}
         },
+        "ft.onto.base_ontology.Classification": {
+            "is_selected": false,
+            "is_shown": true,
+            "attributes": {}
+        },
         "ft.onto.base_ontology.Document": {
             "is_selected": false,
             "is_shown": true,
@@ -163,5 +168,12 @@
         "left": "default-meta",
         "right": "default-attribute",
         "center-bottom": "disable"
+    },
+    "remoteConfigs": {
+        "pipelineUrl": "",
+        "doValidation": false,
+        "expectedName": "",
+        "inputFormat": "string",
+        "expectedRecords": {}
     }
 }

--- a/tests/forte/data/ontology/test_specs/test_stave_ontology.json
+++ b/tests/forte/data/ontology/test_specs/test_stave_ontology.json
@@ -1,0 +1,376 @@
+{
+    "name": "base_ontology",
+    "definitions": [
+        {
+            "entry_name": "ft.onto.base_ontology.Token",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "A span based annotation :class:`Token`, used to represent a token or a word.",
+            "attributes": [
+                {
+                    "name": "pos",
+                    "type": "str"
+                },
+                {
+                    "name": "ud_xpos",
+                    "type": "str",
+                    "description": "Language specific pos tag. Used in CoNLL-U Format. Refer to https://universaldependencies.org/format.html"
+                },
+                {
+                    "name": "lemma",
+                    "type": "str",
+                    "description": "Lemma or stem of word form."
+                },
+                {
+                    "name": "chunk",
+                    "type": "str"
+                },
+                {
+                    "name": "ner",
+                    "type": "str"
+                },
+                {
+                    "name": "sense",
+                    "type": "str"
+                },
+                {
+                    "name": "is_root",
+                    "type": "bool"
+                },
+                {
+                    "name": "ud_features",
+                    "type": "Dict",
+                    "key_type": "str",
+                    "value_type": "str"
+                },
+                {
+                    "name": "ud_misc",
+                    "type": "Dict",
+                    "key_type": "str",
+                    "value_type": "str"
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.Subword",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "Used to represent subword tokenization results.",
+            "attributes": [
+                {
+                    "name": "is_first_segment",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.Classification",
+            "parent_entry": "forte.data.ontology.top.Generics",
+            "description": "Used to store values for classification prediction",
+            "attributes": [
+                {
+                    "name": "classification_result",
+                    "type": "Dict",
+                    "key_type": "str",
+                    "value_type": "float"
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.Document",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "A span based annotation `Document`, normally used to represent a document.",
+            "attributes": [
+                {
+                    "name": "document_class",
+                    "type": "List",
+                    "item_type": "str",
+                    "description": "A list of class names that the document belongs to."
+                },
+                {
+                    "name": "sentiment",
+                    "type": "Dict",
+                    "key_type": "str",
+                    "value_type": "float"
+                },
+                {
+                    "name": "classifications",
+                    "type": "Dict",
+                    "key_type": "str",
+                    "value_type": "ft.onto.base_ontology.Classification",
+                    "description": "Stores the classification results for this document. The key is the name/task of the classification, the value is an classification object storing the results."
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.Sentence",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "A span based annotation `Sentence`, normally used to represent a sentence.",
+            "attributes": [
+                {
+                    "name": "speaker",
+                    "type": "str"
+                },
+                {
+                    "name": "part_id",
+                    "type": "int"
+                },
+                {
+                    "name": "sentiment",
+                    "type": "Dict",
+                    "key_type": "str",
+                    "value_type": "float"
+                },
+                {
+                    "name": "classification",
+                    "type": "Dict",
+                    "key_type": "str",
+                    "value_type": "float"
+                },
+                {
+                    "name": "classifications",
+                    "type": "Dict",
+                    "key_type": "str",
+                    "value_type": "ft.onto.base_ontology.Classification",
+                    "description": "Stores the classification results for this sentence. The key is the name/task of the classification, the value is an classification object storing the results."
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.Phrase",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "A span based annotation `Phrase`.",
+            "attributes": [
+                {
+                    "name": "phrase_type",
+                    "type": "str"
+                },
+                {
+                    "name": "headword",
+                    "type": "ft.onto.base_ontology.Token"
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.UtteranceContext",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "`UtteranceContext` represents the context part in dialogue."
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.Utterance",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "A span based annotation `Utterance`, normally used to represent an utterance in dialogue.",
+            "attributes": [
+                {
+                    "name": "speaker",
+                    "type": "str"
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.PredicateArgument",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "A span based annotation `PredicateArgument`, normally used to represent an argument of a predicate, can be linked to the predicate via the predicate link.",
+            "attributes": [
+                {
+                    "name": "ner_type",
+                    "type": "str"
+                },
+                {
+                    "name": "predicate_lemma",
+                    "type": "str"
+                },
+                {
+                    "name": "is_verb",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.EntityMention",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "A span based annotation `EntityMention`, normally used to represent an Entity Mention in a piece of text.",
+            "attributes": [
+                {
+                    "name": "ner_type",
+                    "type": "str"
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.EventMention",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "A span based annotation `EventMention`, used to refer to a mention of an event.",
+            "attributes": [
+                {
+                    "name": "event_type",
+                    "type": "str"
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.PredicateMention",
+            "parent_entry": "ft.onto.base_ontology.Phrase",
+            "description": "A span based annotation `PredicateMention`, normally used to represent a predicate (normally verbs) in a piece of text.",
+            "attributes": [
+                {
+                    "name": "predicate_lemma",
+                    "type": "str"
+                },
+                {
+                    "name": "framenet_id",
+                    "type": "str"
+                },
+                {
+                    "name": "is_verb",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.PredicateLink",
+            "parent_entry": "forte.data.ontology.top.Link",
+            "description": "A `Link` type entry which represent a semantic role link between a predicate and its argument.",
+            "attributes": [
+                {
+                    "name": "arg_type",
+                    "type": "str",
+                    "description": "The predicate link type."
+                }
+            ],
+            "parent_type": "ft.onto.base_ontology.PredicateMention",
+            "child_type": "ft.onto.base_ontology.PredicateArgument"
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.Dependency",
+            "parent_entry": "forte.data.ontology.top.Link",
+            "description": "A `Link` type entry which represent a syntactic dependency.",
+            "attributes": [
+                {
+                    "name": "dep_label",
+                    "type": "str",
+                    "description": "The dependency label."
+                },
+                {
+                    "name": "rel_type",
+                    "type": "str"
+                }
+            ],
+            "parent_type": "ft.onto.base_ontology.Token",
+            "child_type": "ft.onto.base_ontology.Token"
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.EnhancedDependency",
+            "parent_entry": "forte.data.ontology.top.Link",
+            "description": "A `Link` type entry which represent a enhanced dependency: \n https://universaldependencies.org/u/overview/enhanced-syntax.html",
+            "attributes": [
+                {
+                    "name": "dep_label",
+                    "type": "str",
+                    "description": "The enhanced dependency label in Universal Dependency."
+                }
+            ],
+            "parent_type": "ft.onto.base_ontology.Token",
+            "child_type": "ft.onto.base_ontology.Token"
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.RelationLink",
+            "parent_entry": "forte.data.ontology.top.Link",
+            "description": "A `Link` type entry which represent a relation between two entity mentions",
+            "attributes": [
+                {
+                    "name": "rel_type",
+                    "type": "str",
+                    "description": "The type of the relation."
+                }
+            ],
+            "parent_type": "ft.onto.base_ontology.EntityMention",
+            "child_type": "ft.onto.base_ontology.EntityMention"
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.CrossDocEntityRelation",
+            "parent_entry": "forte.data.ontology.top.MultiPackLink",
+            "description": "A `Link` type entry which represent a relation between two entity mentions across the packs.",
+            "attributes": [
+                {
+                    "name": "rel_type",
+                    "type": "str",
+                    "description": "The type of the relation."
+                }
+            ],
+            "parent_type": "ft.onto.base_ontology.EntityMention",
+            "child_type": "ft.onto.base_ontology.EntityMention"
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.CoreferenceGroup",
+            "parent_entry": "forte.data.ontology.top.Group",
+            "description": "A group type entry that take `EntityMention`, as members, used to represent coreferent group of entities.",
+            "member_type": "ft.onto.base_ontology.EntityMention"
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.EventRelation",
+            "parent_entry": "forte.data.ontology.top.Link",
+            "description": "A `Link` type entry which represent a relation between two event mentions.",
+            "attributes": [
+                {
+                    "name": "rel_type",
+                    "type": "str",
+                    "description": "The type of the relation."
+                }
+            ],
+            "parent_type": "ft.onto.base_ontology.EventMention",
+            "child_type": "ft.onto.base_ontology.EventMention"
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.CrossDocEventRelation",
+            "parent_entry": "forte.data.ontology.top.MultiPackLink",
+            "description": "A `Link` type entry which represent a relation between two event mentions across the packs.",
+            "attributes": [
+                {
+                    "name": "rel_type",
+                    "type": "str",
+                    "description": "The type of the relation."
+                }
+            ],
+            "parent_type": "ft.onto.base_ontology.EventMention",
+            "child_type": "ft.onto.base_ontology.EventMention"
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.ConstituentNode",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "A span based annotation `ConstituentNode` to represent constituents in constituency parsing. This can also sentiment values annotated on the nodes.",
+            "attributes": [
+                {
+                    "name": "label",
+                    "type": "str"
+                },
+                {
+                    "name": "sentiment",
+                    "type": "Dict",
+                    "key_type": "str",
+                    "value_type": "float"
+                },
+                {
+                    "name": "is_root",
+                    "type": "bool"
+                },
+                {
+                    "name": "is_leaf",
+                    "type": "bool"
+                },
+                {
+                    "name": "parent_node",
+                    "type": "ft.onto.base_ontology.ConstituentNode"
+                },
+                {
+                    "name": "children_nodes",
+                    "type": "List",
+                    "item_type": "ft.onto.base_ontology.ConstituentNode"
+                }
+            ]
+        },
+        {
+            "entry_name": "ft.onto.base_ontology.Title",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "A span based annotation `Title`, normally used to represent a title."
+        }
+    ]
+}

--- a/tests/forte/processors/stave_processor_test.py
+++ b/tests/forte/processors/stave_processor_test.py
@@ -38,22 +38,21 @@ class TestStaveProcessor(unittest.TestCase):
     def setUp(self):
 
         self._port: int = 8880
-        self._file_dir_path = os.path.dirname(__file__)
+        _file_dir_path: str = os.path.dirname(__file__)
         self._project_name: str = "serialization_pipeline_test"
         self._dataset_dir: str = os.path.abspath(
             os.path.join(
-                self._file_dir_path, "../../../", "data_samples/ontonotes/00/"
+                _file_dir_path, "../../../", "data_samples/ontonotes/00/"
             )
+        )
+        self._test_specs_dir: str = os.path.abspath(
+            os.path.join(_file_dir_path, "../data/ontology/test_specs/")
         )
         self._stave_processor = StaveProcessor()
 
         self.pl = Pipeline[DataPack](
-            ontology_file=os.path.abspath(
-                os.path.join(
-                    self._file_dir_path,
-                    "../../../",
-                    "forte/ontology_specs/base_ontology.json",
-                )
+            ontology_file=os.path.join(
+                self._test_specs_dir, "test_stave_ontology.json"
             )
         )
         self.pl.set_reader(OntonotesReader())
@@ -93,12 +92,8 @@ class TestStaveProcessor(unittest.TestCase):
 
         # Check default project configuration
         with open(
-            os.path.abspath(
-                os.path.join(
-                    self._file_dir_path,
-                    "../data/ontology/test_specs/",
-                    "test_project_configuration.json",
-                )
+            os.path.join(
+                self._test_specs_dir, "test_project_configuration.json"
             ),
             "r",
         ) as f:


### PR DESCRIPTION
This PR fixes #489 . 

### Description of changes
- Add a fixed ontology `test_specs/test_stave_ontology.json` that is only meant for test of project config generation. This should not be changed in future updates.
- Based on `test_stave_ontology.json`, `test_project_configuration.json` is regenerated from the frontend page when adding a new project in Stave. The fixed ontology goes through [createDefaultConfig](https://github.com/asyml/stave/blob/d42c3816a3e0ec9d4eb6cb0c9d6fb48ac93a5861/src/app/pages/Projects.tsx#L140) to create a new version of default project configuration.
- `stave_processor.py` is updated to reflect [a recent change](https://github.com/asyml/stave/commit/c09ab5d987109dd1c45459da08a2582fcea85877#) in [createDefaultConfig](https://github.com/asyml/stave/blob/d42c3816a3e0ec9d4eb6cb0c9d6fb48ac93a5861/src/app/pages/Projects.tsx#L140) where a new field `remoteConfig` is introduced to project configuration.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
`stave_processor_test.py` is updated to test project config generation on fixed ontology file.
