### PR TITLE
Update to support python3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,18 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.6, 3.7 ]
         torch-version: [ 1.5.0, 1.6.0 ]
         tensorflow-version: [ 1.15.0 ]
         include:
+          - python-version: 3.8
+            torch-version: 1.7.1
+            tensorflow-version: 2.2.0
+          - python-version: 3.8
+            torch-version: 1.8.1
+            tensorflow-version: 2.2.0
           - python-version: 3.9
             torch-version: 1.7.1
             tensorflow-version: 2.5.0
           - python-version: 3.9
             torch-version: 1.8.1
-            tensorflow-version: 2.5.0
-          - python-version: 3.9
-            torch-version: 1.9.0
             tensorflow-version: 2.5.0
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.9 ]
-        torch-version: [ 1.5.0, 1.6.0, 1.7.1, 1.8.1, 1.9.0 ]
-        tensorflow-version: [ 1.15.0, 2.5.0 ]
-        exclude:
+        python-version: [ 3.6, 3.7 ]
+        torch-version: [ 1.5.0, 1.6.0 ]
+        tensorflow-version: [ 1.15.0 ]
+        include:
           - python-version: 3.9
-            torch-version: [ 1.5.0, 1.6.0 ]
-            tensorflow-version: 1.15.0
+            torch-version: [ 1.7.1, 1.8.1, 1.9.0 ]
+            tensorflow-version: 2.5.0
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         tensorflow-version: [ 1.15.0 ]
         include:
           - python-version: 3.9
-            torch-version: [ 1.7.1, 1.8.1, 1.9.0 ]
+            torch-version: 1.9.0
             tensorflow-version: 2.5.0
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,12 @@ jobs:
         tensorflow-version: [ 1.15.0 ]
         include:
           - python-version: 3.9
+            torch-version: 1.7.1
+            tensorflow-version: 2.5.0
+          - python-version: 3.9
+            torch-version: 1.8.1
+            tensorflow-version: 2.5.0
+          - python-version: 3.9
             torch-version: 1.9.0
             tensorflow-version: 2.5.0
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7 ]
+        python-version: [ 3.6, 3.7, 3.9 ]
         torch-version: [ 1.5.0, 1.6.0 ]
         tensorflow-version: [ 1.15.0 ]
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: [ 3.6, 3.7, 3.9 ]
         torch-version: [ 1.7.1, 1.8.0 ]
-        tensorflow-version: [ 1.15.0 ]
+        tensorflow-version: [ 2.5.0 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7 ]
+        python-version: [ 3.6, 3.7, 3.8 ]
         torch-version: [ 1.5.0, 1.6.0 ]
         tensorflow-version: [ 1.15.0 ]
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ 3.6, 3.7, 3.9 ]
-        torch-version: [ 1.5.0, 1.6.0 ]
+        torch-version: [ 1.7.1, 1.8.0 ]
         tensorflow-version: [ 1.15.0 ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,12 @@ jobs:
     strategy:
       matrix:
         python-version: [ 3.6, 3.7, 3.9 ]
-        torch-version: [ 1.7.1, 1.8.0 ]
-        tensorflow-version: [ 2.5.0 ]
+        torch-version: [ 1.5.0, 1.6.0, 1.7.1, 1.8.1, 1.9.0 ]
+        tensorflow-version: [ 1.15.0, 2.5.0 ]
+        exclude:
+          - python-version: 3.9
+            torch-version: [ 1.5.0, 1.6.0 ]
+            tensorflow-version: 1.15.0
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -24,14 +24,14 @@ setuptools.setup(
 
     install_requires=[
         'sortedcontainers==2.1.0',
-        'numpy==1.16.6',
+        'numpy>=1.16.6',
         'jsonpickle==1.4',
         'pyyaml==5.4',
         'smart-open==1.8.4',
         'typed_astunparse==2.1.4',
         'funcsigs==1.0.2',
         'mypy_extensions==0.4.3',
-        'typed_ast==1.4.3',
+        'typed_ast>=1.4.3',
         'jsonschema==3.0.2',
         'texar-pytorch',
         'typing>=3.7.4;python_version<"3.5"',

--- a/setup.py
+++ b/setup.py
@@ -24,14 +24,14 @@ setuptools.setup(
 
     install_requires=[
         'sortedcontainers==2.1.0',
-        'numpy==1.16.5',
+        'numpy==1.16.6',
         'jsonpickle==1.4',
         'pyyaml==5.4',
         'smart-open==1.8.4',
         'typed_astunparse==2.1.4',
         'funcsigs==1.0.2',
         'mypy_extensions==0.4.3',
-        'typed_ast==1.4.0',
+        'typed_ast==1.4.3',
         'jsonschema==3.0.2',
         'texar-pytorch',
         'typing>=3.7.4;python_version<"3.5"',


### PR DESCRIPTION
This PR added support for python3.9. 

### Description of changes
- `setup.py`
    - Update `numpy` version to `>=1.16.6`
    - Update `typed-ast` version to `>=1.4.3`

### Possible influences of this PR.
Potential dependency issues after updating `numpy` and `typed-ast` to higher version.

### Test Conducted
`.github/workflows/main.yml` is updated to test python3.8 and 3.9:
- Add two tests for python3.8:
    - python-version: [ 3.8 ]
    - torch-version: [ 1.7.1, 1.8.1 ]
    - tensorflow-version: [ 2.2.0 ]
- Add two tests for python3.9:
    - python-version: [ 3.9 ]
    - torch-version: [ 1.7.1, 1.8.1 ]
    - tensorflow-version: [ 2.5.0 ]
