### PR TITLE
Add test cases for top entries as part of the attributes.

### DIFF
--- a/tests/forte/data/ontology/ontology_code_generator_test.py
+++ b/tests/forte/data/ontology/ontology_code_generator_test.py
@@ -84,6 +84,7 @@ class GenerateOntologyTest(unittest.TestCase):
             ["ft/onto/ft_module", "custom/user/custom_module"],
         ),
         ("race_qa_onto", ["ft/onto/race_qa_ontology"]),
+        ("test_top_attribute", ["ft/onto/test_top_attribute"]),
     )
     def test_generated_code(self, value):
         input_file_name, file_paths = value

--- a/tests/forte/data/ontology/test_outputs/ft/onto/test_top_attribute.py
+++ b/tests/forte/data/ontology/test_outputs/ft/onto/test_top_attribute.py
@@ -1,0 +1,56 @@
+# ***automatically_generated***
+# ***source json:tests/forte/data/ontology/test_specs/test_top_attribute.json***
+# flake8: noqa
+# mypy: ignore-errors
+# pylint: skip-file
+"""
+Automatically generated ontology test_top_attribute. Do not change manually.
+"""
+
+from dataclasses import dataclass
+from forte.data.data_pack import DataPack
+from forte.data.ontology.top import Annotation
+from forte.data.ontology.top import Generics
+from forte.data.ontology.top import Group
+from forte.data.ontology.top import Link
+from forte.data.ontology.top import MultiPackGeneric
+from forte.data.ontology.top import MultiPackGroup
+from forte.data.ontology.top import MultiPackLink
+from forte.data.ontology.top import Query
+from typing import Optional
+
+__all__ = [
+    "Item",
+]
+
+
+@dataclass
+class Item(Annotation):
+    """
+    Attributes:
+        query (Optional[Query]):
+        generics (Optional[Generics]):
+        link (Optional[Link]):
+        group (Optional[Group]):
+        multiPackLink (Optional[MultiPackLink]):
+        multiPackGroup (Optional[MultiPackGroup]):
+        multiPackGeneric (Optional[MultiPackGeneric]):
+    """
+
+    query: Optional[Query]
+    generics: Optional[Generics]
+    link: Optional[Link]
+    group: Optional[Group]
+    multiPackLink: Optional[MultiPackLink]
+    multiPackGroup: Optional[MultiPackGroup]
+    multiPackGeneric: Optional[MultiPackGeneric]
+
+    def __init__(self, pack: DataPack, begin: int, end: int):
+        super().__init__(pack, begin, end)
+        self.query: Optional[Query] = None
+        self.generics: Optional[Generics] = None
+        self.link: Optional[Link] = None
+        self.group: Optional[Group] = None
+        self.multiPackLink: Optional[MultiPackLink] = None
+        self.multiPackGroup: Optional[MultiPackGroup] = None
+        self.multiPackGeneric: Optional[MultiPackGeneric] = None

--- a/tests/forte/data/ontology/test_specs/test_top_attribute.json
+++ b/tests/forte/data/ontology/test_specs/test_top_attribute.json
@@ -1,0 +1,39 @@
+{
+    "name": "test_top_attribute",
+    "definitions": [
+        {
+            "entry_name": "ft.onto.test_top_attribute.Item",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "attributes": [
+                {
+                    "name": "query",
+                    "type": "forte.data.ontology.top.Query"
+                },
+                {
+                    "name": "generics",
+                    "type": "forte.data.ontology.top.Generics"
+                },
+                {
+                    "name": "link",
+                    "type": "forte.data.ontology.top.Link"
+                },
+                {
+                    "name": "group",
+                    "type": "forte.data.ontology.top.Group"
+                },
+                {
+                    "name": "multiPackLink",
+                    "type": "forte.data.ontology.top.MultiPackLink"
+                },
+                {
+                    "name": "multiPackGroup",
+                    "type": "forte.data.ontology.top.MultiPackGroup"
+                },
+                {
+                    "name": "multiPackGeneric",
+                    "type": "forte.data.ontology.top.MultiPackGeneric"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds some test cases for ontology generation where top entries are used as attributes. 

### Description of changes
Add the test ontology and the expected output, where the top attributes such as `top.Query`
are used as the attribute.

### Possible influences of this PR.
Only added the test cases.

### Test Conducted
Describe what test cases are included for the PR.
