### PR TITLE
Update version requirement of stave

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
         "wikipedia": ["rdflib==4.2.2"],
         # transformers 4.10.0 will break the translation model we used here
         "augment": ["transformers>=3.1, <=4.9.2", "nltk"],
-        "stave": ["stave==0.0.1.dev12"],
+        "stave": ["stave>=0.0.1.dev12"],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This PR updates stave version requirement from `==0.0.1.dev12` to `>=0.0.1.dev12`. 

### Description of changes
Describe what are the changes, and how they solve the problem.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
