### PR TITLE
Make some base selector, such as reverse selection

### DIFF
--- a/forte/common/configurable.py
+++ b/forte/common/configurable.py
@@ -66,7 +66,7 @@ class Configurable(ABC):
     ) -> Config:
         """
         Create the configuration by merging the
-        provided config with the default_configs.
+        provided config with the `default_configs`.
 
         The following config conventions are expected:
           - The top level key can be a special `@config_path`.

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -305,8 +305,8 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         return self._packs
 
     @property
-    def pack_names(self) -> Set[str]:
-        return set(self._pack_names)
+    def pack_names(self) -> List[str]:
+        return self._pack_names
 
     def update_pack(self, named_packs: Dict[str, DataPack]):
         for pack_name, pack in named_packs.items():

--- a/forte/data/selector.py
+++ b/forte/data/selector.py
@@ -66,8 +66,37 @@ class SinglePackSelector(Selector[MultiPack, DataPack]):
     This is the base class that select a DataPack from MultiPack.
     """
 
-    def select(self, pack: MultiPack) -> Iterator[DataPack]:
+    def select(self, m_pack: MultiPack) -> Iterator[DataPack]:
+        reverse = self.configs.reverse_selection
+
+        for name, pack in m_pack.iter_packs():
+            if reverse:
+                if not self.will_select(name, pack, m_pack):
+                    yield pack
+            else:
+                if self.will_select(name, pack, m_pack):
+                    yield pack
+
+    def will_select(
+        self, pack_name: str, pack: DataPack, multi_pack: MultiPack
+    ) -> bool:
+        """
+        Implement this method to return a boolean value whether the
+        pack will be selected.
+
+        Args:
+            pack_name: The name of the pack to be selected.
+            pack: The pack that needed to be determined whether it will be
+              selected.
+            multi_pack: The original multi pack.
+
+        Returns: A boolean value to indicate whether `pack` will be returned.
+        """
         raise NotImplementedError
+
+    @classmethod
+    def default_configs(cls) -> Dict[str, Any]:
+        return {"reverse_selection": False}
 
 
 class NameMatchSelector(SinglePackSelector):
@@ -91,25 +120,23 @@ class NameMatchSelector(SinglePackSelector):
         super().__init__()
         self.select_name = select_name
 
-    def select(self, m_pack: MultiPack) -> Iterator[DataPack]:
-        matches = 0
-        for name, pack in m_pack.iter_packs():
-            if name == self.select_name:
-                matches += 1
-                yield pack
-
-        if matches == 0:
-            raise ValueError(
-                f"Pack name {self.select_name}" f" not in the MultiPack"
-            )
+    def will_select(
+        self, pack_name: str, pack: DataPack, multi_pack: MultiPack
+    ):
+        return pack_name == self.select_name
 
     def initialize(
         self, configs: Optional[Union[Config, Dict[str, Any]]] = None
     ):
+        super().initialize(configs)
+        try:
+            configs_ = configs.todict()
+        except AttributeError:
+            configs_ = {} if configs is None else configs
+
         if self.select_name is not None:
-            super().initialize({"select_name": self.select_name})
-        else:
-            super().initialize(configs)
+            configs_["select_name"] = self.select_name
+        super().initialize(configs_)
 
         if self.configs["select_name"] is None:
             raise ValueError("select_name shouldn't be None.")
@@ -140,21 +167,25 @@ class RegexNameMatchSelector(SinglePackSelector):
         super().__init__()
         self.select_name = select_name
 
-    def select(self, m_pack: MultiPack) -> Iterator[DataPack]:
-        if len(m_pack.packs) == 0:
-            raise ValueError("Multi-pack is empty")
-        else:
-            for name, pack in m_pack.iter_packs():
-                if re.match(self.select_name, name):  # type: ignore
-                    yield pack
+    def will_select(
+        self, pack_name: str, pack: DataPack, multi_pack: MultiPack
+    ) -> bool:
+        return re.match(self.select_name, pack_name) is not None
 
     def initialize(
         self, configs: Optional[Union[Config, Dict[str, Any]]] = None
     ):
+        super().initialize(configs)
+
+        try:
+            configs_ = configs.todict()
+        except AttributeError:
+            configs_ = {} if configs is None else configs
+
         if self.select_name is not None:
-            super().initialize({"select_name": self.select_name})
-        else:
-            super().initialize(configs)
+            configs_["select_name"] = self.select_name
+
+        super().initialize(configs_)
 
         if self.configs["select_name"] is None:
             raise ValueError("select_name shouldn't be None.")
@@ -168,20 +199,16 @@ class RegexNameMatchSelector(SinglePackSelector):
 class FirstPackSelector(SinglePackSelector):
     r"""Select the first entry from :class:`MultiPack` and yield it."""
 
-    def select(self, m_pack: MultiPack) -> Iterator[DataPack]:
-        if len(m_pack.packs) == 0:
-            raise ValueError("Multi-pack has no data packs.")
-
-        else:
-            yield m_pack.packs[0]
+    def will_select(
+        self, pack_name: str, pack: DataPack, multi_pack: MultiPack
+    ) -> bool:
+        return multi_pack.pack_names[0] == pack_name
 
 
 class AllPackSelector(SinglePackSelector):
     r"""Select all the packs from :class:`MultiPack` and yield them."""
 
-    def select(self, m_pack: MultiPack) -> Iterator[DataPack]:
-        if len(m_pack.packs) == 0:
-            raise ValueError("Multi-pack has no data packs.")
-
-        else:
-            yield from m_pack.packs
+    def will_select(
+        self, pack_name: str, pack: DataPack, multi_pack: MultiPack
+    ) -> bool:
+        return True

--- a/forte/data/selector.py
+++ b/forte/data/selector.py
@@ -130,7 +130,7 @@ class NameMatchSelector(SinglePackSelector):
     ):
         super().initialize(configs)
         try:
-            configs_ = configs.todict()
+            configs_ = configs.todict()  # type:ignore
         except AttributeError:
             configs_ = {} if configs is None else configs
 
@@ -170,7 +170,7 @@ class RegexNameMatchSelector(SinglePackSelector):
     def will_select(
         self, pack_name: str, pack: DataPack, multi_pack: MultiPack
     ) -> bool:
-        return re.match(self.select_name, pack_name) is not None
+        return re.match(self.select_name, pack_name) is not None  # type:ignore
 
     def initialize(
         self, configs: Optional[Union[Config, Dict[str, Any]]] = None
@@ -178,7 +178,7 @@ class RegexNameMatchSelector(SinglePackSelector):
         super().initialize(configs)
 
         try:
-            configs_ = configs.todict()
+            configs_ = configs.todict()  # type:ignore
         except AttributeError:
             configs_ = {} if configs is None else configs
 

--- a/tests/forte/data/multi_pack_test.py
+++ b/tests/forte/data/multi_pack_test.py
@@ -48,12 +48,12 @@ class DataPackTest(unittest.TestCase):
 
         self.assertEqual(len(self.multi_pack.packs), 3)
         self.assertEqual(
-            self.multi_pack.pack_names, {"left pack", "right pack", "new pack"}
+            self.multi_pack.pack_names, ["left pack", "right pack", "new pack"]
         )
 
     def test_rename_pack(self):
         self.multi_pack.rename_pack("right pack", "last pack")
-        self.assertEqual(self.multi_pack.pack_names, {"left pack", "last pack"})
+        self.assertEqual(self.multi_pack.pack_names, ["left pack", "last pack"])
 
     def test_multipack_groups(self):
         """

--- a/tests/forte/data/selector_test.py
+++ b/tests/forte/data/selector_test.py
@@ -48,14 +48,25 @@ class SelectorTest(unittest.TestCase):
         for doc_id, pack in zip(doc_ids, packs):
             self.assertEqual(doc_id, pack.pack_name)
 
+        # Test reverse selection.
+        selector.initialize(
+            configs={"select_name": "pack1", "reverse_selection": True},
+        )
+        packs = selector.select(self.multi_pack)
+        doc_ids = ["2", "Three"]
+        for doc_id, pack in zip(doc_ids, packs):
+            self.assertEqual(doc_id, pack.pack_name)
+
     def test_name_match_selector_backward_compatability(self) -> None:
         selector = NameMatchSelector(select_name="pack1")
+        selector.initialize()
         packs = selector.select(self.multi_pack)
         doc_ids = ["1"]
         for doc_id, pack in zip(doc_ids, packs):
             self.assertEqual(doc_id, pack.pack_name)
 
         selector = NameMatchSelector("pack1")
+        selector.initialize()
         packs = selector.select(self.multi_pack)
         doc_ids = ["1"]
         for doc_id, pack in zip(doc_ids, packs):
@@ -71,27 +82,53 @@ class SelectorTest(unittest.TestCase):
         for doc_id, pack in zip(doc_ids, packs):
             self.assertEqual(doc_id, pack.pack_name)
 
+        # Test reverse selection.
+        selector.initialize(
+            {"select_name": "^.*\\d$", "reverse_selection": True}
+        )
+        packs = selector.select(self.multi_pack)
+        doc_ids = ["Three"]
+        for doc_id, pack in zip(doc_ids, packs):
+            self.assertEqual(doc_id, pack.pack_name)
+
     def test_regex_name_match_selector_backward_compatability(self) -> None:
         selector = RegexNameMatchSelector(select_name="^.*\\d$")
+        selector.initialize()
         packs = selector.select(self.multi_pack)
         doc_ids = ["1", "2"]
         for doc_id, pack in zip(doc_ids, packs):
             self.assertEqual(doc_id, pack.pack_name)
 
+        # Test different configuration method (backward compatibility)
         selector = RegexNameMatchSelector("^.*\\d$")
+        selector.initialize()
         packs = selector.select(self.multi_pack)
         doc_ids = ["1", "2"]
+        for doc_id, pack in zip(doc_ids, packs):
+            self.assertEqual(doc_id, pack.pack_name)
+
+        # Test reverse selection.
+        selector.initialize({"reverse_selection": True})
+        packs = selector.select(self.multi_pack)
+        doc_ids = ["Three"]
         for doc_id, pack in zip(doc_ids, packs):
             self.assertEqual(doc_id, pack.pack_name)
 
     def test_first_pack_selector(self) -> None:
         selector = FirstPackSelector()
+        selector.initialize()
         packs = list(selector.select(self.multi_pack))
         self.assertEqual(len(packs), 1)
         self.assertEqual(packs[0].pack_name, "1")
 
+        # Test reverse selection.
+        selector.initialize({"reverse_selection": True})
+        packs = list(selector.select(self.multi_pack))
+        self.assertEqual(len(packs), len(self.multi_pack.packs) - 1)
+
     def test_all_pack_selector(self) -> None:
         selector = AllPackSelector()
+        selector.initialize()
         packs = selector.select(self.multi_pack)
         doc_ids = ["1", "2", "Three"]
         for doc_id, pack in zip(doc_ids, packs):


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/538. 

### Description of changes
1. Make `SinglePackSelector` to control the basic selection flow, and the sub classes only return a boolean from `will_select` function
2. The default configs are added to the `SinglePackSelector`.
3. Some changes are made to make sure the configs are correctly inherited between classes. 

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
