### PR TITLE
Fixing a few configuration bugs

### DIFF
--- a/forte/data/caster.py
+++ b/forte/data/caster.py
@@ -54,7 +54,8 @@ class MultiPackBoxer(Caster[DataPack, MultiPack]):
         Returns: An iterator that produces the boxed multi pack.
 
         """
-        p = MultiPack()
+        pack_name = pack.pack_name + "_multi" if pack.pack_name else None
+        p = MultiPack(pack_name=pack_name)
         p.add_pack_(pack, self.configs.pack_name)
         return p
 

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -176,7 +176,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             "specific data pack to get text."
         )
 
-    def add_pack(self, ref_name: Optional[str] = None) -> DataPack:
+    def add_pack(
+        self, ref_name: Optional[str] = None, pack_name: Optional[str] = None
+    ) -> DataPack:
         """
         Create a data pack and add it to this multi pack. If `ref_name` is
         provided, it will be used to index the data pack. Otherwise, a default
@@ -185,7 +187,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         Args:
             ref_name (str): The pack name used to reference this data pack from
-              the multi pack.
+              the multi pack. If none, the reference name will not be set.
+            pack_name (str): The pack name of the data pack (itself). If none,
+              the name will not be set.
 
         Returns: The newly created data pack.
 
@@ -199,7 +203,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
                 f"{type(ref_name)}"
             )
 
-        pack: DataPack = DataPack()
+        pack: DataPack = DataPack(pack_name=pack_name)
         self.add_pack_(pack, ref_name)
         return pack
 

--- a/forte/data/ontology/ontology_code_generator.py
+++ b/forte/data/ontology/ontology_code_generator.py
@@ -60,6 +60,7 @@ from forte.data.ontology.code_generation_objects import (
     DictProperty,
     EntryTree,
 )
+
 # Builtin and local imports required in the generated python modules.
 from forte.data.ontology.ontology_code_const import (
     REQUIRED_IMPORTS,

--- a/forte/data/ontology/ontology_code_generator.py
+++ b/forte/data/ontology/ontology_code_generator.py
@@ -60,7 +60,6 @@ from forte.data.ontology.code_generation_objects import (
     DictProperty,
     EntryTree,
 )
-
 # Builtin and local imports required in the generated python modules.
 from forte.data.ontology.ontology_code_const import (
     REQUIRED_IMPORTS,
@@ -1048,6 +1047,14 @@ class OntologyCodeGenerator:
                 constraint_type_name = this_manager.get_name_to_use(
                     constraint_type_
                 )
+
+                if constraint_type_name is None:
+                    raise TypeNotDeclaredException(
+                        f"The type {constraint_type_} is not defined but it is "
+                        f"specified in {schema_key} of the definition of "
+                        f"{schema['entry_name']}. Please define them before "
+                        f"this entry type."
+                    )
 
                 # TODO: cannot handle constraints that contain self-references.
                 # self_ref = entry_name.class_name == constraint_type_

--- a/forte/data/ontology/top.py
+++ b/forte/data/ontology/top.py
@@ -222,6 +222,8 @@ class Link(BaseLink):
         Args:
             parent: The parent entry.
         """
+        import pdb
+        pdb.set_trace()
         if not isinstance(parent, self.ParentType):
             raise TypeError(
                 f"The parent of {type(self)} should be an "

--- a/forte/data/ontology/top.py
+++ b/forte/data/ontology/top.py
@@ -222,8 +222,6 @@ class Link(BaseLink):
         Args:
             parent: The parent entry.
         """
-        import pdb
-        pdb.set_trace()
         if not isinstance(parent, self.ParentType):
             raise TypeError(
                 f"The parent of {type(self)} should be an "

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -16,11 +16,10 @@ Base class for Pipeline module.
 """
 
 import itertools
-import logging
 import json
-from time import time
+import logging
 import sys
-
+from time import time
 from typing import (
     Any,
     Dict,
@@ -34,8 +33,8 @@ from typing import (
     Set,
 )
 
-import yaml
 import uvicorn
+import yaml
 from fastapi import FastAPI
 from pydantic import BaseModel
 
@@ -47,10 +46,10 @@ from forte.common.exception import (
 )
 from forte.common.resources import Resources
 from forte.data.base_pack import PackType
-from forte.data.ontology.ontology_code_generator import OntologyCodeGenerator
-from forte.data.ontology.code_generation_objects import EntryTree
 from forte.data.base_reader import BaseReader
 from forte.data.caster import Caster
+from forte.data.ontology.code_generation_objects import EntryTree
+from forte.data.ontology.ontology_code_generator import OntologyCodeGenerator
 from forte.data.selector import Selector, DummySelector
 from forte.evaluation.base.base_evaluator import Evaluator
 from forte.pipeline_component import PipelineComponent
@@ -301,7 +300,9 @@ class Pipeline(Generic[PackType]):
                         class_name=selector_config["type"],
                         class_args=selector_config.get("kwargs", {}),
                     ),
-                    selector_config=selector_config.get("configs"),
+                    selector_config=None
+                    if selector_config is None
+                    else selector_config.get("configs"),
                 )
 
         # Set pipeline states and resources

--- a/forte/processors/base/pack_processor.py
+++ b/forte/processors/base/pack_processor.py
@@ -15,7 +15,6 @@
 Processors that process pack.
 """
 from abc import ABC
-from typing import Optional
 
 from forte.data.base_pack import PackType
 from forte.data.data_pack import DataPack
@@ -49,16 +48,3 @@ class MultiPackProcessor(BasePackProcessor[MultiPack], ABC):
 
     def _process(self, input_pack: MultiPack):
         raise NotImplementedError
-
-    def new_data_pack(self, pack_name: Optional[str] = None) -> DataPack:
-        """
-        Create a new data pack using the current pack manager.
-
-        Args:
-            pack_name (str, Optional): The name to be used for the pack. If not
-              set, the pack name will remained unset.
-
-        Returns:
-
-        """
-        return DataPack(pack_name)

--- a/forte/processors/base/writers.py
+++ b/forte/processors/base/writers.py
@@ -186,7 +186,7 @@ class MultiPackWriter(MultiPackProcessor):
 
         if self.configs.output_dir is None:
             raise ProcessorConfigError(
-                f"`output_dir` is not specified for the writer."
+                "`output_dir` is not specified for the writer."
             )
 
         pack_paths = os.path.join(self.configs.output_dir, self.pack_idx)

--- a/forte/processors/base/writers.py
+++ b/forte/processors/base/writers.py
@@ -21,6 +21,7 @@ import posixpath
 from abc import abstractmethod, ABC
 from typing import Optional, Any, Dict
 
+from forte.common import ProcessorConfigError
 from forte.common.configuration import Config
 from forte.common.resources import Resources
 from forte.data.base_pack import BasePack
@@ -182,6 +183,11 @@ class MultiPackWriter(MultiPackProcessor):
     def initialize(self, resources: Resources, configs: Config):
         # pylint: disable=attribute-defined-outside-init,consider-using-with
         super().initialize(resources, configs)
+
+        if self.configs.output_dir is None:
+            raise ProcessorConfigError(
+                f"`output_dir` is not specified for the writer."
+            )
 
         pack_paths = os.path.join(self.configs.output_dir, self.pack_idx)
         ensure_dir(pack_paths)


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/542

### Description of changes
1. Allow `caster` to assign a name to multipack automatically
2. When creating new data pack in multi packs, allow assigning a name
3. Add clear exception when constraint_type is not set in ontology code generator
4. Do not query `selector_config` when it is None.
5. Remove unused function `new_data_pack` in pack_processor
6. Check for `output_dir` in writers.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
