### PR TITLE
added static methods to infer pack type

### DIFF
--- a/forte/data/base_reader.py
+++ b/forte/data/base_reader.py
@@ -106,8 +106,8 @@ class BaseReader(PipelineComponent[PackType], ABC):
         """
         return {"zip_pack": False, "serialize_method": "jsonpickle"}
 
-    @property
-    def pack_type(self):
+    @staticmethod
+    def pack_type():
         raise NotImplementedError
 
     @abstractmethod
@@ -210,7 +210,7 @@ class BaseReader(PipelineComponent[PackType], ABC):
                     if self._cache_directory is not None:
                         self.cache_data(collection, pack, not_first)
 
-                    if not isinstance(pack, self.pack_type):
+                    if not isinstance(pack, self.pack_type()):
                         raise ValueError(
                             f"No Pack object read from the given "
                             f"collection {collection}, returned {type(pack)}."
@@ -355,10 +355,10 @@ class BaseReader(PipelineComponent[PackType], ABC):
         with open(cache_filename, "r", encoding="utf-8") as cache_file:
             for line in cache_file:
                 pack = DataPack.from_string(line.strip())
-                if not isinstance(pack, self.pack_type):
+                if not isinstance(pack, self.pack_type()):
                     raise TypeError(
                         f"Pack deserialized from {cache_filename} "
-                        f"is {type(pack)}, but expect {self.pack_type}"
+                        f"is {type(pack)}, but expect {self.pack_type()}"
                     )
                 yield pack
 
@@ -380,8 +380,8 @@ class BaseReader(PipelineComponent[PackType], ABC):
 class PackReader(BaseReader[DataPack], ABC):
     r"""A Pack Reader reads data into :class:`DataPack`."""
 
-    @property
-    def pack_type(self):
+    @staticmethod
+    def pack_type():
         return DataPack
 
 
@@ -390,6 +390,6 @@ class MultiPackReader(BaseReader[MultiPack], ABC):
     data readers which return :class:`MultiPack`.
     """
 
-    @property
-    def pack_type(self):
+    @staticmethod
+    def pack_type():
         return MultiPack

--- a/forte/data/caster.py
+++ b/forte/data/caster.py
@@ -37,6 +37,14 @@ class Caster(
     def cast(self, pack: InputPackType) -> OutputPackType:
         raise NotImplementedError
 
+    @staticmethod
+    def input_pack_type():
+        raise NotImplementedError
+
+    @staticmethod
+    def output_pack_type():
+        raise NotImplementedError
+
 
 class MultiPackBoxer(Caster[DataPack, MultiPack]):
     """
@@ -62,3 +70,11 @@ class MultiPackBoxer(Caster[DataPack, MultiPack]):
     @classmethod
     def default_configs(cls):
         return {"pack_name": "default"}
+
+    @staticmethod
+    def input_pack_type():
+        return DataPack
+
+    @staticmethod
+    def output_pack_type():
+        return MultiPack

--- a/forte/data/readers/misc_readers.py
+++ b/forte/data/readers/misc_readers.py
@@ -98,12 +98,12 @@ class BaseRawPackReader(BaseReader, ABC):
 
 
 class RawPackReader(BaseRawPackReader):
-    @property
-    def pack_type(self):
+    @staticmethod
+    def pack_type():
         return DataPack
 
 
 class RawMultiPackReader(BaseRawPackReader):
-    @property
-    def pack_type(self):
+    @staticmethod
+    def pack_type():
         return MultiPack

--- a/tests/forte/data/datapack_type_infer_test.py
+++ b/tests/forte/data/datapack_type_infer_test.py
@@ -1,0 +1,39 @@
+import unittest
+from ddt import data, ddt
+
+from forte.data.caster import MultiPackBoxer
+from forte.data.data_pack import DataPack
+from forte.data.multi_pack import MultiPack
+from forte.data.readers.misc_readers import RawPackReader, RawMultiPackReader
+from forte.data.readers.multipack_sentence_reader import MultiPackSentenceReader
+from forte.data.readers.multipack_terminal_reader import MultiPackTerminalReader
+from forte.data.readers.plaintext_reader import PlainTextReader
+
+
+@ddt
+class DataPackTypeInferTest(unittest.TestCase):
+
+    @data(
+        PlainTextReader,
+        RawPackReader,
+    )
+    def test_datapack_reader(self, component):
+        reader = component()
+        self.assertTrue(reader.pack_type() is DataPack)
+
+    @data(
+        MultiPackSentenceReader,
+        MultiPackTerminalReader,
+        RawMultiPackReader,
+    )
+    def test_multipack_reader(self, component):
+        reader = component()
+        self.assertTrue(reader.pack_type() is MultiPack)
+
+    @data(
+        MultiPackBoxer,
+    )
+    def test_multipack_boxer(self, component):
+        caster = component()
+        self.assertTrue(caster.input_pack_type() is DataPack)
+        self.assertTrue(caster.output_pack_type() is MultiPack)


### PR DESCRIPTION
This PR fixes [Issue #551](https://github.com/asyml/forte/issues/551).

### Description of changes

- Reader: change `pack_type` from `property` to `staticmethod`.
- Caster: add static method `input_pack_type` and `output_pack_type`.

### Possible influences of this PR.

- Reader: `pack_type` now should be used as function call, _e.g._ `Reader.pack_type()` instead of `Reader.pack_type`.
- Caster: now it is able to infer input/output data type by `Caster.input_pack_type()`/`Caster.output_pack_type()`.

### Test Conducted
None