### PR TITLE
Type Key Removal in Configs

### DIFF
--- a/forte/processors/data_augment/algorithms/eda_processors.py
+++ b/forte/processors/data_augment/algorithms/eda_processors.py
@@ -278,16 +278,12 @@ class RandomSwapDataAugmentProcessor(ReplacementDataAugmentProcessor):
             "other_entry_policy": {
                 # to use Texar hyperparams 'kwargs' must
                 # accompany with 'type'
-                "type": "",
-                "kwargs": {
-                    "ft.onto.base_ontology.Document": "auto_align",
-                    "ft.onto.base_ontology.Sentence": "auto_align",
-                },
+                "ft.onto.base_ontology.Document": "auto_align",
+                "ft.onto.base_ontology.Sentence": "auto_align",
             },
             "alpha": 0.1,
             "augment_pack_names": {
-                "type": "",
-                "kwargs": {"input_src": "augmented_input_src"},
+                "input_src": "augmented_input_src",
             },
         }
 
@@ -308,9 +304,7 @@ class RandomInsertionDataAugmentProcessor(ReplacementDataAugmentProcessor):
     def _augment(self, input_pack: MultiPack, aug_pack_names: List[str]):
         replacement_op = create_class_with_kwargs(
             self.configs["data_aug_op"],
-            class_args={
-                "configs": self.configs["data_aug_op_config"]["kwargs"]
-            },
+            class_args={"configs": self.configs["data_aug_op_config"]},
         )
         augment_entry = get_class(self.configs["augment_entry"])
 
@@ -352,29 +346,22 @@ class RandomInsertionDataAugmentProcessor(ReplacementDataAugmentProcessor):
             {
                 "augment_entry": "ft.onto.base_ontology.Token",
                 "other_entry_policy": {
-                    "type": "",
-                    "kwargs": {
-                        "ft.onto.base_ontology.Document": "auto_align",
-                        "ft.onto.base_ontology.Sentence": "auto_align",
-                    },
+                    "ft.onto.base_ontology.Document": "auto_align",
+                    "ft.onto.base_ontology.Sentence": "auto_align",
                 },
                 "data_aug_op": "forte.processors.data_augment.algorithms."
                 "dictionary_replacement_op.DictionaryReplacementOp",
                 "data_aug_op_config": {
-                    "type": "",
-                    "kwargs": {
-                        "dictionary_class": (
-                            "forte.processors.data_augment."
-                            "algorithms.dictionary.WordnetDictionary"
-                        ),
-                        "prob": 1.0,
-                        "lang": "eng",
-                    },
+                    "dictionary_class": (
+                        "forte.processors.data_augment."
+                        "algorithms.dictionary.WordnetDictionary"
+                    ),
+                    "prob": 1.0,
+                    "lang": "eng",
                 },
                 "alpha": 0.1,
                 "augment_pack_names": {
-                    "type": "",
-                    "kwargs": {"input_src": "augmented_input_src"},
+                    "input_src": "augmented_input_src",
                 },
                 "stopwords": english_stopwords,
             }
@@ -411,17 +398,13 @@ class RandomDeletionDataAugmentProcessor(ReplacementDataAugmentProcessor):
             {
                 "augment_entry": "ft.onto.base_ontology.Token",
                 "other_entry_policy": {
-                    "type": "",
-                    "kwargs": {
-                        "ft.onto.base_ontology.Document": "auto_align",
-                        "ft.onto.base_ontology.Sentence": "auto_align",
-                    },
+                    "ft.onto.base_ontology.Document": "auto_align",
+                    "ft.onto.base_ontology.Sentence": "auto_align",
                 },
-                "data_aug_op_config": {"type": "", "kwargs": {}},
+                "data_aug_op_config": {},
                 "alpha": 0.1,
                 "augment_pack_names": {
-                    "type": "",
-                    "kwargs": {"input_src": "augmented_input_src"},
+                    "input_src": "augmented_input_src",
                 },
             }
         )

--- a/forte/processors/data_augment/algorithms/word_splitting_processor.py
+++ b/forte/processors/data_augment/algorithms/word_splitting_processor.py
@@ -149,16 +149,12 @@ class RandomWordSplitDataAugmentProcessor(ReplacementDataAugmentProcessor):
             {
                 "augment_entry": "ft.onto.base_ontology.Token",
                 "other_entry_policy": {
-                    "type": "",
-                    "kwargs": {
-                        "ft.onto.base_ontology.Document": "auto_align",
-                        "ft.onto.base_ontology.Sentence": "auto_align",
-                    },
+                    "ft.onto.base_ontology.Document": "auto_align",
+                    "ft.onto.base_ontology.Sentence": "auto_align",
                 },
                 "alpha": 0.1,
                 "augment_pack_names": {
-                    "type": "",
-                    "kwargs": {"input_src": "augmented_input_src"},
+                    "input_src": "augmented_input_src",
                 },
             }
         )

--- a/forte/processors/data_augment/base_data_augment_processor.py
+++ b/forte/processors/data_augment/base_data_augment_processor.py
@@ -279,7 +279,7 @@ class ReplacementDataAugmentProcessor(BaseDataAugmentProcessor):
 
     def initialize(self, resources: Resources, configs: Config):
         super().initialize(resources, configs)
-        self._other_entry_policy = self.configs["other_entry_policy"]["kwargs"]
+        self._other_entry_policy = self.configs["other_entry_policy"]
 
     def _overlap_with_existing(self, pid: int, begin: int, end: int) -> bool:
         r"""
@@ -744,7 +744,7 @@ class ReplacementDataAugmentProcessor(BaseDataAugmentProcessor):
         replacement_op = create_class_with_kwargs(
             self.configs["data_aug_op"],
             class_args={
-                "configs": self.configs["data_aug_op_config"]["kwargs"]
+                "configs": self.configs["data_aug_op_config"]
             },
         )
         augment_entry = get_class(self.configs["augment_entry"])
@@ -760,20 +760,20 @@ class ReplacementDataAugmentProcessor(BaseDataAugmentProcessor):
         aug_pack_names: List[str] = []
 
         # Check if the DataPack exists.
-        for pack_name in self.configs["augment_pack_names"]["kwargs"].keys():
+        for pack_name in self.configs["augment_pack_names"].keys():
             if pack_name in input_pack.pack_names:
                 aug_pack_names.append(pack_name)
 
-        if len(self.configs["augment_pack_names"]["kwargs"].keys()) == 0:
+        if len(self.configs["augment_pack_names"].keys()) == 0:
             # Augment all the DataPacks if not specified.
             aug_pack_names = list(input_pack.pack_names)
 
         self._augment(input_pack, aug_pack_names)
         new_packs: List[Tuple[str, DataPack]] = []
         for aug_pack_name in aug_pack_names:
-            new_pack_name: str = self.configs["augment_pack_names"][
-                "kwargs"
-            ].get(aug_pack_name, "augmented_" + aug_pack_name)
+            new_pack_name: str = self.configs["augment_pack_names"].get(
+                aug_pack_name, "augmented_" + aug_pack_name
+            )
             data_pack = input_pack.get_pack(aug_pack_name)
             new_pack = self._auto_align_annotations(
                 data_pack=data_pack,
@@ -875,9 +875,10 @@ class ReplacementDataAugmentProcessor(BaseDataAugmentProcessor):
         """
         return {
             "augment_entry": "ft.onto.base_ontology.Sentence",
-            "other_entry_policy": {"type": "", "kwargs": {}},
+            "other_entry_policy": {},
             "type": "data_augmentation_op",
             "data_aug_op": "",
-            "data_aug_op_config": {"type": "", "kwargs": {}},
-            "augment_pack_names": {"type": "", "kwargs": {}},
+            "data_aug_op_config": {},
+            "augment_pack_names": {},
+            "@no_typecheck": ["other_entry_policy", "data_aug_op_config", "augment_pack_names"]
         }

--- a/forte/processors/data_augment/base_data_augment_processor.py
+++ b/forte/processors/data_augment/base_data_augment_processor.py
@@ -743,9 +743,7 @@ class ReplacementDataAugmentProcessor(BaseDataAugmentProcessor):
         """
         replacement_op = create_class_with_kwargs(
             self.configs["data_aug_op"],
-            class_args={
-                "configs": self.configs["data_aug_op_config"]
-            },
+            class_args={"configs": self.configs["data_aug_op_config"]},
         )
         augment_entry = get_class(self.configs["augment_entry"])
 
@@ -880,5 +878,9 @@ class ReplacementDataAugmentProcessor(BaseDataAugmentProcessor):
             "data_aug_op": "",
             "data_aug_op_config": {},
             "augment_pack_names": {},
-            "@no_typecheck": ["other_entry_policy", "data_aug_op_config", "augment_pack_names"]
+            "@no_typecheck": [
+                "other_entry_policy",
+                "data_aug_op_config",
+                "augment_pack_names",
+            ],
         }

--- a/tests/forte/processors/base/data_augment_replacement_processor_test.py
+++ b/tests/forte/processors/base/data_augment_replacement_processor_test.py
@@ -144,16 +144,13 @@ class TestReplacementDataAugmentProcessor(unittest.TestCase):
         processor_config = {
             "augment_entry": "ft.onto.base_ontology.Token",
             "other_entry_policy": {
-                "type": "",
-                "kwargs": {
-                    "ft.onto.base_ontology.Document": "auto_align",
-                    "ft.onto.base_ontology.Sentence": "auto_align",
-                },
+                "ft.onto.base_ontology.Document": "auto_align",
+                "ft.onto.base_ontology.Sentence": "auto_align",
             },
             "type": "data_augmentation_op",
             "data_aug_op": replacer_op,
-            "data_aug_op_config": {"type": "", "kwargs": {}},
-            "augment_pack_names": {"kwargs": {"input": "augmented_input"}},
+            "data_aug_op_config": {},
+            "augment_pack_names": {},
         }
 
         nlp.set_reader(reader=StringReader())
@@ -230,12 +227,12 @@ class TestReplacementDataAugmentProcessor(unittest.TestCase):
         processor_config = {
             "augment_entry": "ft.onto.base_ontology.Token",
             "other_entry_policy": {
-                "kwargs": {"ft.onto.base_ontology.Sentence": "auto_align"}
+                "ft.onto.base_ontology.Sentence": "auto_align"
             },
             "type": "data_augmentation_op",
             "data_aug_op": replacer_op,
-            "data_aug_op_config": {"kwargs": {}},
-            "augment_pack_names": {"kwargs": {}},
+            "data_aug_op_config": {},
+            "augment_pack_names": {},
         }
 
         nlp.initialize()

--- a/tests/forte/processors/data_augment/algorithms/back_translation_augmenter_test.py
+++ b/tests/forte/processors/data_augment/algorithms/back_translation_augmenter_test.py
@@ -17,8 +17,8 @@ Unit tests for back translation replacement op.
 
 import unittest
 import random
-from forte.data.data_pack import DataPack
 from ft.onto.base_ontology import Sentence
+from forte.data.data_pack import DataPack
 from forte.processors.data_augment.algorithms.back_translation_op import (
     BackTranslationOp,
 )

--- a/tests/forte/processors/data_augment/algorithms/embedding_similarity_replacement_op_test.py
+++ b/tests/forte/processors/data_augment/algorithms/embedding_similarity_replacement_op_test.py
@@ -95,25 +95,19 @@ class TestEmbeddingSimilarityReplacementOp(unittest.TestCase):
         processor_config = {
             "augment_entry": "ft.onto.base_ontology.Token",
             "other_entry_policy": {
-                "type": "",
-                "kwargs": {
-                    "ft.onto.base_ontology.Document": "auto_align",
-                    "ft.onto.base_ontology.Sentence": "auto_align",
-                },
+                "ft.onto.base_ontology.Document": "auto_align",
+                "ft.onto.base_ontology.Sentence": "auto_align",
             },
             "type": "data_augmentation_op",
             "data_aug_op": "forte.processors.data_augment.algorithms"
             ".embedding_similarity_replacement_op."
             "EmbeddingSimilarityReplacementOp",
             "data_aug_op_config": {
-                "type": "",
-                "kwargs": {
-                    "vocab_path": self.abs_vocab_path,
-                    "embed_hparams": self.embed_hparams,
-                    "top_k": 1,
-                },
+                "vocab_path": self.abs_vocab_path,
+                "embed_hparams": self.embed_hparams,
+                "top_k": 1,
             },
-            "augment_pack_names": {"kwargs": {"input": "augmented_input"}},
+            "augment_pack_names": {"input": "augmented_input"},
         }
         nlp.add(
             component=ReplacementDataAugmentProcessor(), config=processor_config

--- a/tests/forte/processors/data_augment/algorithms/word_splitting_processor_test.py
+++ b/tests/forte/processors/data_augment/algorithms/word_splitting_processor_test.py
@@ -141,7 +141,7 @@ class TestWordSplittingProcessor(unittest.TestCase):
     ):
         entity_config = {
             "other_entry_policy": {
-                "kwargs": {"ft.onto.base_ontology.EntityMention": "auto_align"}
+                "ft.onto.base_ontology.EntityMention": "auto_align"
             }
         }
         self.nlp.add(


### PR DESCRIPTION
### Description of changes
Removal of the `type` parameter in configs of data augmentation processors.

### Possible influences of this PR.
This PR will help reduce confusion regarding the `type=""` that appeared in DA processors until now.

### Test Conducted
Tested the working of these changes on all DA methods that inherited the `base_data_augment_processor`.
