### PR TITLE
Bug544fix

### DIFF
--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -304,15 +304,13 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
     def purge_deleted_packs(self) -> bool:
         """
-        Purge deleted packs from (3) lists previous set to None inplace (in order to keep index
-        of the pack the same).
-        Caution: after the purge the index would change (if there were deleted packs before the
-        purge)
+        Purge deleted packs from lists previous set to -1, empty or none to keep index unchanged
+        Caution: after the purge the index would change.
 
         Args:
 
         Returns:
-
+            True if successful
         """
 
         # Remove those None in place and shrink the _pack_ref list.

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -248,7 +248,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         groups_with_pack_for_removal = []
         g: MultiPackGroup
         for g in self.get(MultiPackGroup):
-            #e: Annotation
+            # e: Annotation
             for e in g.get_members():
                 if e.pack_id == pack.pack_id:
                     groups_with_pack_for_removal.append(g)
@@ -260,10 +260,10 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             if clean_invalid_entries:
                 # clean links and groups
                 for link in links_with_pack_for_removal:
-                    # delete_entry should be able to take care of related indexes
+                    # delete_entry will take care of related indexes
                     self.delete_entry(link)
                 for g in groups_with_pack_for_removal:
-                    # delete_entry should be able to take care of related indexes
+                    # delete_entry will take care of related indexes
                     self.delete_entry(g)
             else:  # raise exception according to requirement
                 raise ValueError(

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -267,9 +267,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
                     self.delete_entry(g)
             else:  # raise exception according to requirement
                 raise ValueError(
-                    f"The pack to be removed has cross-pack references."
-                    f" Please set clean_invalid_entries to be True to auto-remove all references"
-                    f" to this pack"
+                    "The pack to be removed has cross-pack references."
+                    " Please set clean_invalid_entries to be True to "
+                    " auto-remove all references to this pack"
                 )
 
         # To keep the remaining element 's index unchanged, set to None in
@@ -310,12 +310,14 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         """
 
-        # Remove those None in place and shrink the _pack_ref list. Caution: item index will change
+        # Remove those None in place and shrink the _pack_ref list.
+        # Caution: item index will change
         for index in range(len(self._pack_ref) - 1, 0, -1):
             if self._pack_ref.__getitem__(index) is None:
                 self._pack_ref.__delitem__(index)
 
-        # Remove those None in place and shrink the _pack_names list. Caution: item index will change
+        # Remove those None in place and shrink the _pack_names list.
+        # Caution: item index will change
         for index in range(len(self._pack_names) - 1, 0, -1):
             if self._pack_names.__getitem__(index) is None:
                 self._pack_names.__delitem__(index)

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -177,27 +177,27 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         )
 
     def remove_pack(
-            self, index_of_pack: int, clean_invalid_entries: bool = False
+        self, index_of_pack: int, clean_invalid_entries: bool = False
     ) -> bool:
         """
-                Remove a data pack from multi pack. Remove the pack with index.
+        Remove a data pack from multi pack. Remove the pack with index.
 
-                Note that remove_pack means some cross pack reference entries such as MultiPackLink
-                may become invalid.
+        Note that remove_pack means some cross pack reference entries such as MultiPackLink
+        may become invalid.
 
-                Args:
-                    index_of_pack (int): The index of pack for removal from
-                      the multi pack. If invalid, no pack will be deleted (exception?).
-                    clean_invalid_entries (bool): .
+        Args:
+            index_of_pack (int): The index of pack for removal from
+              the multi pack. If invalid, no pack will be deleted (exception?).
+            clean_invalid_entries (bool): .
 
-                Returns: .
-                    True if successful
+        Returns: .
+            True if successful
 
-                Exceptions:
-                    if clean_invalid_entries is set to False and the DataPack to be removed have cross-pack-reference,
-                    ValueError will eb raised.
+        Exceptions:
+            if clean_invalid_entries is set to False and the DataPack to be removed have cross-pack-reference,
+            ValueError will eb raised.
 
-                """
+        """
         pack = self.get_pack_at(index_of_pack)
 
         if pack is None or (not isinstance(pack, DataPack)):
@@ -210,7 +210,10 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         return self.remove_pack_(pack, index_of_pack, clean_invalid_entries)
 
     def remove_pack_(
-            self, pack: DataPack, index_of_pack: int, clean_invalid_entries: bool = False
+        self,
+        pack: DataPack,
+        index_of_pack: int,
+        clean_invalid_entries: bool = False,
     ) -> bool:
         """
         Remove a existing data pack in the multi pack. Per discussion on effects of the data pack removal,
@@ -236,7 +239,10 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         for link in self.get(MultiPackLink):
             parent_entry_pid = link.get_parent().pack_id
             child_entry_pid = link.get_child().pack_id
-            if parent_entry_pid == pack.pack_id or child_entry_pid == pack.pack_id:
+            if (
+                parent_entry_pid == pack.pack_id
+                or child_entry_pid == pack.pack_id
+            ):
                 links_with_pack_for_removal.append(link)
 
         groups_with_pack_for_removal = []
@@ -247,7 +253,10 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
                 if e.pack_id == pack.pack_id:
                     groups_with_pack_for_removal.append(g)
 
-        if len(links_with_pack_for_removal) > 0 or len(groups_with_pack_for_removal) > 0:
+        if (
+            len(links_with_pack_for_removal) > 0
+            or len(groups_with_pack_for_removal) > 0
+        ):
             if clean_invalid_entries:
                 # clean links and groups
                 for link in links_with_pack_for_removal:
@@ -263,25 +272,29 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
                 )
 
         # To keep the remaining element 's index unchanged, set to None in place instead of direct removal
-        self._pack_ref.__setitem__(index_of_pack, None)  # remove(pack.pack_id) if don't care index change
+        self._pack_ref.__setitem__(
+            index_of_pack, None
+        )  # remove(pack.pack_id) if don't care index change
         # Remove the reverse mapping from pack id to the pack index.
         self._inverse_pack_ref.pop(pack.pack_id)
 
         # Remove the pack names. To keep the remaining element's index unchanged, set to None instead of direct removal
         tmp_pack_name = self.pack_names[index_of_pack]
-        self._pack_names.__setitem__(index_of_pack, None)  # remove(tmp_pack_name) if don't care index change
+        self._pack_names.__setitem__(
+            index_of_pack, None
+        )  # remove(tmp_pack_name) if don't care index change
 
         # Remove the reverse mapping from name to the pack index.
         self._name_index.pop(tmp_pack_name)
 
         # Remove Reference to the real packs.
-        self._packs.__setitem__(index_of_pack, None)  # remove(pack) if don't care index change
+        self._packs.__setitem__(
+            index_of_pack, None
+        )  # remove(pack) if don't care index change
 
         return True
 
-    def purge_deleted_packs(
-            self
-    ) -> bool:
+    def purge_deleted_packs(self) -> bool:
         """
         Purge deleted packs from (3) lists previous set to None inplace (in order to keep index of the pack the same).
         Caution after the purge the index would change (if there were deleted packs before the purge)
@@ -310,7 +323,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         return True
 
     def add_pack(
-            self, ref_name: Optional[str] = None, pack_name: Optional[str] = None
+        self, ref_name: Optional[str] = None, pack_name: Optional[str] = None
     ) -> DataPack:
         """
         Create a data pack and add it to this multi pack. If `ref_name` is
@@ -533,21 +546,21 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             pack.add_all_remaining_entries(component)
 
     def get_data(
-            self,
-            context_type,
-            request: Optional[DataRequest] = None,
-            skip_k: int = 0,
+        self,
+        context_type,
+        request: Optional[DataRequest] = None,
+        skip_k: int = 0,
     ) -> Iterator[Dict[str, Any]]:
         raise NotImplementedError(
             "We haven't implemented get data for multi pack data yet."
         )
 
     def get_single_pack_data(
-            self,
-            pack_index: int,
-            context_type: Type[Annotation],
-            request: Optional[DataRequest] = None,
-            skip_k: int = 0,
+        self,
+        pack_index: int,
+        context_type: Type[Annotation],
+        request: Optional[DataRequest] = None,
+        skip_k: int = 0,
     ) -> Iterator[Dict[str, Any]]:
         r"""Get pack data from one of the packs specified by the name. This is
         equivalent to calling the
@@ -583,8 +596,8 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         )
 
     def get_cross_pack_data(
-            self,
-            request: MdRequest,
+        self,
+        request: MdRequest,
     ):
         r"""
         NOTE: This function is not finished.
@@ -636,7 +649,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         pass
 
     def __add_entry_with_check(
-            self, entry: EntryType, allow_duplicate: bool = True
+        self, entry: EntryType, allow_duplicate: bool = True
     ) -> EntryType:
         r"""Internal method to add an :class:`Entry` object to the
         :class:`MultiPack` object.
@@ -681,10 +694,10 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             return target[target.index(entry)]
 
     def get(  # type: ignore
-            self,
-            entry_type: Union[str, Type[EntryType]],
-            components: Optional[Union[str, List[str]]] = None,
-            include_sub_type=True,
+        self,
+        entry_type: Union[str, Type[EntryType]],
+        components: Optional[Union[str, List[str]]] = None,
+        include_sub_type=True,
     ) -> Iterator[EntryType]:
         """Get entries of `entry_type` from this multi pack.
 
@@ -764,10 +777,10 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
     @classmethod
     def deserialize(
-            cls,
-            data_path: Union[Path, str],
-            serialize_method: str = "jsonpickle",
-            zip_pack: bool = False,
+        cls,
+        data_path: Union[Path, str],
+        serialize_method: str = "jsonpickle",
+        zip_pack: bool = False,
     ) -> "MultiPack":
         """
         Deserialize a Multi Pack from a string. Note that this will only

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -274,8 +274,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         # To keep the remaining element 's index unchanged, set to None in
         # place instead of direct removal
-        self._pack_ref.__setitem__(index_of_pack, int(None))  # remove(pack.pack_id)
-        # in case don't care index change
+        self._pack_ref.__setitem__(
+            index_of_pack, int(None)
+        )  # remove(pack.pack_id) in case don't care index change
 
         # Remove the reverse mapping from pack id to the pack index.
         self._inverse_pack_ref.pop(pack.pack_id)
@@ -283,8 +284,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # Remove the pack names. To keep the remaining element's index
         # unchanged, set to None instead of direct removal
         tmp_pack_name = self.pack_names[index_of_pack]
-        self._pack_names.__setitem__(index_of_pack, str(None))  # remove(tmp_pack_name)
-        # in case don't care index change
+        self._pack_names.__setitem__(
+            index_of_pack, str(None)
+        )  # remove(tmp_pack_name) in case don't care index change
 
         # Remove the reverse mapping from name to the pack index.
         self._name_index.pop(tmp_pack_name)

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -176,6 +176,70 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             "specific data pack to get text."
         )
 
+    def remove_pack(
+        self,  index_of_pack: int, clean_invalid_entries: bool = False
+    ) -> bool:
+        """
+                Remove a data pack from multi pack. Remove the pack with index.
+
+                Note that remove_pack means some cross pack reference entries such as MultiPackLink
+                may become invalid.
+
+                Args:
+                    index_of_pack (int): The index of pack for removal from
+                      the multi pack. If invalid, no pack will be deleted (exception?).
+                    clean_invalid_entries (bool): .
+
+                Returns: .
+
+                """
+        pack = self.get_pack_at(index_of_pack)
+
+        if pack is None or (not isinstance(pack, DataPack)):
+            raise ValueError(
+                f"Object for the index should be pack, but got "
+                f""
+                f"{type(pack)}"
+            )
+
+        return self.remove_pack_(pack,index_of_pack)
+
+    def remove_pack_(
+            self, pack: DataPack, index_of_pack: int, clean_invalid_entries: bool = False
+    ) -> bool:
+        """
+        Remove a existing data pack in the multi pack.
+
+        Args:
+            pack (DataPack): The existing data pack.
+
+        Returns:
+
+        """
+
+        #if (clean_invalid_entries) :
+            # check links and groups
+        # else: if links / groups have references, should raise exception (?)
+
+        # Remove the pack ids of the subpacks. Note that these are UUIDs
+        self._pack_ref.remove(pack.pack_id)    #: List[int] = []
+        # Remove the reverse mapping from pack id to the pack index.
+        self._inverse_pack_ref.pop(pack.pack_id)    #: Dict[int, int] = {}
+
+        # Remove the pack names.
+        # bug here: pack.pack_name is None!
+        tmp_pack_name = self.pack_names[index_of_pack]
+        self._pack_names.remove(tmp_pack_name)  # pack.pack_name ?
+        # Remove the reverse mapping from name to the pack index.
+
+        self._name_index.pop(tmp_pack_name)  #pack.pack_name ?
+
+        # Remove Reference to the real packs.
+        self._packs.remove(pack)
+
+        return True
+
+
     def add_pack(
         self, ref_name: Optional[str] = None, pack_name: Optional[str] = None
     ) -> DataPack:

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -176,9 +176,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             "specific data pack to get text."
         )
 
-    def remove_pack(
-        self, index_of_pack: int, clean_invalid_entries: bool = False
-    ) -> bool:
+    def remove_pack(self, index_of_pack: int, clean_invalid_entries: bool = False) -> bool:
         """
         Remove a data pack from multi pack. Remove the pack with index.
 
@@ -201,11 +199,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         pack = self.get_pack_at(index_of_pack)
 
         if pack is None or (not isinstance(pack, DataPack)):
-            raise ValueError(
-                f"Object for the index should be pack, but got "
-                f""
-                f"{type(pack)}"
-            )
+            raise ValueError(f"Object for the index should be pack, but got " f"" f"{type(pack)}")
 
         return self.remove_pack_(pack, index_of_pack, clean_invalid_entries)
 
@@ -239,10 +233,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         for link in self.get(MultiPackLink):
             parent_entry_pid = link.get_parent().pack_id
             child_entry_pid = link.get_child().pack_id
-            if (
-                parent_entry_pid == pack.pack_id
-                or child_entry_pid == pack.pack_id
-            ):
+            if parent_entry_pid == pack.pack_id or child_entry_pid == pack.pack_id:
                 links_with_pack_for_removal.append(link)
 
         groups_with_pack_for_removal = []
@@ -253,10 +244,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
                 if e.pack_id == pack.pack_id:
                     groups_with_pack_for_removal.append(g)
 
-        if (
-            len(links_with_pack_for_removal) > 0
-            or len(groups_with_pack_for_removal) > 0
-        ):
+        if len(links_with_pack_for_removal) > 0 or len(groups_with_pack_for_removal) > 0:
             if clean_invalid_entries:
                 # clean links and groups
                 for link in links_with_pack_for_removal:
@@ -288,9 +276,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         self._name_index.pop(tmp_pack_name)
 
         # Remove Reference to the real packs.
-        self._packs.__setitem__(
-            index_of_pack, None
-        )  # remove(pack) if don't care index change
+        self._packs.__setitem__(index_of_pack, None)  # remove(pack) if don't care index change
 
         return True
 
@@ -322,9 +308,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         return True
 
-    def add_pack(
-        self, ref_name: Optional[str] = None, pack_name: Optional[str] = None
-    ) -> DataPack:
+    def add_pack(self, ref_name: Optional[str] = None, pack_name: Optional[str] = None) -> DataPack:
         """
         Create a data pack and add it to this multi pack. If `ref_name` is
         provided, it will be used to index the data pack. Otherwise, a default
@@ -343,11 +327,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         if ref_name in self._name_index:
             raise ValueError(f"The name {ref_name} has already been taken.")
         if ref_name is not None and not isinstance(ref_name, str):
-            raise ValueError(
-                f"key of the pack should be str, but got "
-                f""
-                f"{type(ref_name)}"
-            )
+            raise ValueError(f"key of the pack should be str, but got " f"" f"{type(ref_name)}")
 
         pack: DataPack = DataPack(pack_name=pack_name)
         self.add_pack_(pack, ref_name)
@@ -367,16 +347,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         if ref_name in self._name_index:
             raise ValueError(f"The name {ref_name} has already been taken.")
         if ref_name is not None and not isinstance(ref_name, str):
-            raise ValueError(
-                f"key of the pack should be str, but got "
-                f""
-                f"{type(ref_name)}"
-            )
+            raise ValueError(f"key of the pack should be str, but got " f"" f"{type(ref_name)}")
         if not isinstance(pack, DataPack):
-            raise ValueError(
-                f"value of the packs should be DataPack, but "
-                f"got {type(pack)}"
-            )
+            raise ValueError(f"value of the packs should be DataPack, but " f"got {type(pack)}")
 
         pid = pack.pack_id
 
@@ -419,9 +392,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         try:
             return self._inverse_pack_ref[pack_id]
         except KeyError as e:
-            raise ProcessExecutionException(
-                f"Pack {pack_id} is not in this multi-pack."
-            ) from e
+            raise ProcessExecutionException(f"Pack {pack_id} is not in this multi-pack.") from e
 
     def get_pack(self, name: str) -> DataPack:
         """
@@ -551,9 +522,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         request: Optional[DataRequest] = None,
         skip_k: int = 0,
     ) -> Iterator[Dict[str, Any]]:
-        raise NotImplementedError(
-            "We haven't implemented get data for multi pack data yet."
-        )
+        raise NotImplementedError("We haven't implemented get data for multi pack data yet.")
 
     def get_single_pack_data(
         self,
@@ -591,9 +560,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             containing the required annotations and context).
         """
 
-        yield from self.get_pack_at(pack_index).get_data(
-            context_type, request, skip_k
-        )
+        yield from self.get_pack_at(pack_index).get_data(context_type, request, skip_k)
 
     def get_cross_pack_data(
         self,
@@ -648,9 +615,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # TODO: Not finished yet
         pass
 
-    def __add_entry_with_check(
-        self, entry: EntryType, allow_duplicate: bool = True
-    ) -> EntryType:
+    def __add_entry_with_check(self, entry: EntryType, allow_duplicate: bool = True) -> EntryType:
         r"""Internal method to add an :class:`Entry` object to the
         :class:`MultiPack` object.
 
@@ -751,9 +716,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         elif issubclass(entry_type_, MultiPackGeneric):
             entry_iter = self.generics
         else:
-            raise ValueError(
-                f"The entry type: {entry_type_} is not supported by MultiPack."
-            )
+            raise ValueError(f"The entry type: {entry_type_} is not supported by MultiPack.")
 
         all_types: Set[Type]
         if include_sub_type:

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -248,7 +248,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         groups_with_pack_for_removal = []
         g: MultiPackGroup
         for g in self.get(MultiPackGroup):
-            e: Annotation
+            #e: Annotation
             for e in g.get_members():
                 if e.pack_id == pack.pack_id:
                     groups_with_pack_for_removal.append(g)
@@ -274,25 +274,24 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         # To keep the remaining element 's index unchanged, set to None in
         # place instead of direct removal
-        self._pack_ref.__setitem__(
-            index_of_pack, None
-        )  # remove(pack.pack_id) if don't care index change
+        self._pack_ref.__setitem__(index_of_pack, int(None))  # remove(pack.pack_id)
+        # in case don't care index change
+
         # Remove the reverse mapping from pack id to the pack index.
         self._inverse_pack_ref.pop(pack.pack_id)
 
         # Remove the pack names. To keep the remaining element's index
         # unchanged, set to None instead of direct removal
         tmp_pack_name = self.pack_names[index_of_pack]
-        self._pack_names.__setitem__(
-            index_of_pack, None
-        )  # remove(tmp_pack_name) if don't care index change
+        self._pack_names.__setitem__(index_of_pack, str(None))  # remove(tmp_pack_name)
+        # in case don't care index change
 
         # Remove the reverse mapping from name to the pack index.
         self._name_index.pop(tmp_pack_name)
 
         # Remove Reference to the real packs.
         self._packs.__setitem__(
-            index_of_pack, None
+            index_of_pack, DataPack(None)
         )  # remove(pack) if don't care index change
 
         return True

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -277,9 +277,8 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         # vin = int(0)
         # vin = None
-        self._pack_ref.__setitem__(
-            index_of_pack, None  # type: ignore
-        )  # remove(pack.pack_id) in case don't care index change
+        self._pack_ref.__setitem__(index_of_pack, None)  # type: ignore
+        # remove(pack.pack_id) in case don't care index change
 
         # Remove the reverse mapping from pack id to the pack index.
         self._inverse_pack_ref.pop(pack.pack_id)
@@ -296,9 +295,8 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         self._name_index.pop(tmp_pack_name)
 
         # Remove Reference to the real packs.
-        self._packs.__setitem__(
-            index_of_pack, None  # type: ignore
-        )  # remove(pack) if don't care index change
+        self._packs.__setitem__(index_of_pack, None)  # type: ignore
+        # remove(pack) if don't care index change
 
         return True
 

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -275,8 +275,8 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # To keep the remaining element 's index unchanged, set to None in
         # place instead of direct removal
 
-        vin = int(0)
-        vin = None
+        # vin = int(0)
+        # vin = None
         self._pack_ref.__setitem__(
             index_of_pack, -1
         )  # remove(pack.pack_id) in case don't care index change

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -289,7 +289,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         tmp_pack_name = self.pack_names[index_of_pack]
 
         self._pack_names.__setitem__(
-            index_of_pack, None
+            index_of_pack, ""
         )  # remove(tmp_pack_name) in case don't care index change
 
         # Remove the reverse mapping from name to the pack index.
@@ -297,7 +297,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         # Remove Reference to the real packs.
         self._packs.__setitem__(
-            index_of_pack, None
+            index_of_pack, DataPack(None)
         )  # remove(pack) if don't care index change
 
         return True
@@ -324,7 +324,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # Remove those None in place and shrink the _pack_names list.
         # Caution: item index will change
         for index in range(len(self._pack_names) - 1, 0, -1):
-            if self._pack_names.__getitem__(index) is None:
+            if not self._pack_names.__getitem__(index):
                 self._pack_names.__delitem__(index)
 
         # Remove those None in place and shrink the _packs list. Caution: item index will change

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -176,7 +176,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             "specific data pack to get text."
         )
 
-    def remove_pack(self, index_of_pack: int, clean_invalid_entries: bool = False) -> bool:
+    def remove_pack(
+        self, index_of_pack: int, clean_invalid_entries: bool = False
+    ) -> bool:
         """
         Remove a data pack from multi pack. Remove the pack with index.
 
@@ -199,7 +201,11 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         pack = self.get_pack_at(index_of_pack)
 
         if pack is None or (not isinstance(pack, DataPack)):
-            raise ValueError(f"Object for the index should be pack, but got " f"" f"{type(pack)}")
+            raise ValueError(
+                f"Object for the index should be pack, but got "
+                f""
+                f"{type(pack)}"
+            )
 
         return self.remove_pack_(pack, index_of_pack, clean_invalid_entries)
 
@@ -233,7 +239,10 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         for link in self.get(MultiPackLink):
             parent_entry_pid = link.get_parent().pack_id
             child_entry_pid = link.get_child().pack_id
-            if parent_entry_pid == pack.pack_id or child_entry_pid == pack.pack_id:
+            if (
+                parent_entry_pid == pack.pack_id
+                or child_entry_pid == pack.pack_id
+            ):
                 links_with_pack_for_removal.append(link)
 
         groups_with_pack_for_removal = []
@@ -244,7 +253,10 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
                 if e.pack_id == pack.pack_id:
                     groups_with_pack_for_removal.append(g)
 
-        if len(links_with_pack_for_removal) > 0 or len(groups_with_pack_for_removal) > 0:
+        if (
+            len(links_with_pack_for_removal) > 0
+            or len(groups_with_pack_for_removal) > 0
+        ):
             if clean_invalid_entries:
                 # clean links and groups
                 for link in links_with_pack_for_removal:
@@ -276,7 +288,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         self._name_index.pop(tmp_pack_name)
 
         # Remove Reference to the real packs.
-        self._packs.__setitem__(index_of_pack, None)  # remove(pack) if don't care index change
+        self._packs.__setitem__(
+            index_of_pack, None
+        )  # remove(pack) if don't care index change
 
         return True
 
@@ -308,7 +322,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         return True
 
-    def add_pack(self, ref_name: Optional[str] = None, pack_name: Optional[str] = None) -> DataPack:
+    def add_pack(
+        self, ref_name: Optional[str] = None, pack_name: Optional[str] = None
+    ) -> DataPack:
         """
         Create a data pack and add it to this multi pack. If `ref_name` is
         provided, it will be used to index the data pack. Otherwise, a default
@@ -327,7 +343,11 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         if ref_name in self._name_index:
             raise ValueError(f"The name {ref_name} has already been taken.")
         if ref_name is not None and not isinstance(ref_name, str):
-            raise ValueError(f"key of the pack should be str, but got " f"" f"{type(ref_name)}")
+            raise ValueError(
+                f"key of the pack should be str, but got "
+                f""
+                f"{type(ref_name)}"
+            )
 
         pack: DataPack = DataPack(pack_name=pack_name)
         self.add_pack_(pack, ref_name)
@@ -347,9 +367,16 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         if ref_name in self._name_index:
             raise ValueError(f"The name {ref_name} has already been taken.")
         if ref_name is not None and not isinstance(ref_name, str):
-            raise ValueError(f"key of the pack should be str, but got " f"" f"{type(ref_name)}")
+            raise ValueError(
+                f"key of the pack should be str, but got "
+                f""
+                f"{type(ref_name)}"
+            )
         if not isinstance(pack, DataPack):
-            raise ValueError(f"value of the packs should be DataPack, but " f"got {type(pack)}")
+            raise ValueError(
+                f"value of the packs should be DataPack, but "
+                f"got {type(pack)}"
+            )
 
         pid = pack.pack_id
 
@@ -392,7 +419,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         try:
             return self._inverse_pack_ref[pack_id]
         except KeyError as e:
-            raise ProcessExecutionException(f"Pack {pack_id} is not in this multi-pack.") from e
+            raise ProcessExecutionException(
+                f"Pack {pack_id} is not in this multi-pack."
+            ) from e
 
     def get_pack(self, name: str) -> DataPack:
         """
@@ -522,7 +551,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         request: Optional[DataRequest] = None,
         skip_k: int = 0,
     ) -> Iterator[Dict[str, Any]]:
-        raise NotImplementedError("We haven't implemented get data for multi pack data yet.")
+        raise NotImplementedError(
+            "We haven't implemented get data for multi pack data yet."
+        )
 
     def get_single_pack_data(
         self,
@@ -560,7 +591,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             containing the required annotations and context).
         """
 
-        yield from self.get_pack_at(pack_index).get_data(context_type, request, skip_k)
+        yield from self.get_pack_at(pack_index).get_data(
+            context_type, request, skip_k
+        )
 
     def get_cross_pack_data(
         self,
@@ -615,7 +648,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # TODO: Not finished yet
         pass
 
-    def __add_entry_with_check(self, entry: EntryType, allow_duplicate: bool = True) -> EntryType:
+    def __add_entry_with_check(
+        self, entry: EntryType, allow_duplicate: bool = True
+    ) -> EntryType:
         r"""Internal method to add an :class:`Entry` object to the
         :class:`MultiPack` object.
 
@@ -716,7 +751,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         elif issubclass(entry_type_, MultiPackGeneric):
             entry_iter = self.generics
         else:
-            raise ValueError(f"The entry type: {entry_type_} is not supported by MultiPack.")
+            raise ValueError(
+                f"The entry type: {entry_type_} is not supported by MultiPack."
+            )
 
         all_types: Set[Type]
         if include_sub_type:

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -274,8 +274,13 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         # To keep the remaining element 's index unchanged, set to None in
         # place instead of direct removal
+
+        """
+        @type vin: int
+        """
+        vin = None
         self._pack_ref.__setitem__(
-            index_of_pack, int(None)
+            index_of_pack, vin
         )  # remove(pack.pack_id) in case don't care index change
 
         # Remove the reverse mapping from pack id to the pack index.
@@ -284,8 +289,13 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # Remove the pack names. To keep the remaining element's index
         # unchanged, set to None instead of direct removal
         tmp_pack_name = self.pack_names[index_of_pack]
+
+        """
+        @type vsn: str
+        """
+        vsn = None
         self._pack_names.__setitem__(
-            index_of_pack, str(None)
+            index_of_pack, vsn
         )  # remove(tmp_pack_name) in case don't care index change
 
         # Remove the reverse mapping from name to the pack index.

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -278,7 +278,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # vin = int(0)
         # vin = None
         self._pack_ref.__setitem__(
-            index_of_pack, -1
+            index_of_pack, None  # type: ignore
         )  # remove(pack.pack_id) in case don't care index change
 
         # Remove the reverse mapping from pack id to the pack index.
@@ -297,7 +297,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         # Remove Reference to the real packs.
         self._packs.__setitem__(
-            index_of_pack, DataPack(None)
+            index_of_pack, None  # type: ignore
         )  # remove(pack) if don't care index change
 
         return True

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -289,7 +289,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         tmp_pack_name = self.pack_names[index_of_pack]
 
         self._pack_names.__setitem__(
-            index_of_pack, str(None)
+            index_of_pack, None
         )  # remove(tmp_pack_name) in case don't care index change
 
         # Remove the reverse mapping from name to the pack index.
@@ -297,7 +297,7 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
         # Remove Reference to the real packs.
         self._packs.__setitem__(
-            index_of_pack, DataPack(None)
+            index_of_pack, None
         )  # remove(pack) if don't care index change
 
         return True

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -275,12 +275,10 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # To keep the remaining element 's index unchanged, set to None in
         # place instead of direct removal
 
-        # """
-        # @type vin: int
-        # """
+        vin = int(0)
         vin = None
         self._pack_ref.__setitem__(
-            index_of_pack, vin
+            index_of_pack, -1
         )  # remove(pack.pack_id) in case don't care index change
 
         # Remove the reverse mapping from pack id to the pack index.
@@ -290,9 +288,8 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # unchanged, set to None instead of direct removal
         tmp_pack_name = self.pack_names[index_of_pack]
 
-        vsn = None
         self._pack_names.__setitem__(
-            index_of_pack, vsn
+            index_of_pack, str(None)
         )  # remove(tmp_pack_name) in case don't care index change
 
         # Remove the reverse mapping from name to the pack index.

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -275,9 +275,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # To keep the remaining element 's index unchanged, set to None in
         # place instead of direct removal
 
-        """
-        @type vin: int
-        """
+        # """
+        # @type vin: int
+        # """
         vin = None
         self._pack_ref.__setitem__(
             index_of_pack, vin
@@ -290,9 +290,6 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         # unchanged, set to None instead of direct removal
         tmp_pack_name = self.pack_names[index_of_pack]
 
-        """
-        @type vsn: str
-        """
         vsn = None
         self._pack_names.__setitem__(
             index_of_pack, vsn

--- a/forte/data/multi_pack.py
+++ b/forte/data/multi_pack.py
@@ -194,8 +194,8 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             True if successful
 
         Exceptions:
-            if clean_invalid_entries is set to False and the DataPack to be removed have cross-pack-reference,
-            ValueError will eb raised.
+            if clean_invalid_entries is set to False and the DataPack to be removed have
+            cross-pack-reference, ValueError will be raised.
 
         """
         pack = self.get_pack_at(index_of_pack)
@@ -216,9 +216,9 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
         clean_invalid_entries: bool = False,
     ) -> bool:
         """
-        Remove a existing data pack in the multi pack. Per discussion on effects of the data pack removal,
-        to prevent index of other packs being changed, (temporarily) set this empty position to None in order
-        to keep the index for the packs intact
+        Remove a existing data pack in the multi pack. Per discussion on effects of the data pack
+        removal, to prevent index of other packs being changed, (temporarily) set this empty
+        position to None in order to keep the index for the packs intact
 
         Args:
             pack (DataPack): The existing data pack.
@@ -229,8 +229,8 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             True if successful
 
         Exceptions:
-            if clean_invalid_entries is set to False and the DataPack to be removed have cross-pack-reference,
-            ValueError will eb raised.
+            if clean_invalid_entries is set to False and the DataPack to be removed have
+            cross-pack-reference, ValueError will be raised.
         """
 
         # check if the pack to be removed has any cross pack links/groups
@@ -268,17 +268,20 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
             else:  # raise exception according to requirement
                 raise ValueError(
                     f"The pack to be removed has cross-pack references."
-                    f" Please set clean_invalid_entries to be True to auto-remove all references to this pack"
+                    f" Please set clean_invalid_entries to be True to auto-remove all references"
+                    f" to this pack"
                 )
 
-        # To keep the remaining element 's index unchanged, set to None in place instead of direct removal
+        # To keep the remaining element 's index unchanged, set to None in
+        # place instead of direct removal
         self._pack_ref.__setitem__(
             index_of_pack, None
         )  # remove(pack.pack_id) if don't care index change
         # Remove the reverse mapping from pack id to the pack index.
         self._inverse_pack_ref.pop(pack.pack_id)
 
-        # Remove the pack names. To keep the remaining element's index unchanged, set to None instead of direct removal
+        # Remove the pack names. To keep the remaining element's index
+        # unchanged, set to None instead of direct removal
         tmp_pack_name = self.pack_names[index_of_pack]
         self._pack_names.__setitem__(
             index_of_pack, None
@@ -296,8 +299,10 @@ class MultiPack(BasePack[Entry, MultiPackLink, MultiPackGroup]):
 
     def purge_deleted_packs(self) -> bool:
         """
-        Purge deleted packs from (3) lists previous set to None inplace (in order to keep index of the pack the same).
-        Caution after the purge the index would change (if there were deleted packs before the purge)
+        Purge deleted packs from (3) lists previous set to None inplace (in order to keep index
+        of the pack the same).
+        Caution: after the purge the index would change (if there were deleted packs before the
+        purge)
 
         Args:
 

--- a/tests/forte/data/multi_pack_test.py
+++ b/tests/forte/data/multi_pack_test.py
@@ -317,7 +317,7 @@ class DataPackTest(unittest.TestCase):
         self.expected_name_list_1 = [
             "left pack",
             "right pack",
-            None,
+            "",
             "remove pack 11",
             "remove pack 12",
             "remove pack 13",
@@ -325,17 +325,17 @@ class DataPackTest(unittest.TestCase):
         self.expected_name_list_2 = [
             "left pack",
             "right pack",
-            None,
-            None,
+            "",
+            "",
             "remove pack 12",
             "remove pack 13",
         ]
         self.expected_name_list_3 = [
             "left pack",
             "right pack",
-            None,
-            None,
-            None,
+            "",
+            "",
+            "",
             "remove pack 13",
         ]
         self.expected_name_list_purge = [

--- a/tests/forte/data/multi_pack_test.py
+++ b/tests/forte/data/multi_pack_test.py
@@ -31,31 +31,11 @@ class DataPackTest(unittest.TestCase):
         self.data_pack1 = self.multi_pack.add_pack(ref_name="left pack")
         self.data_pack2 = self.multi_pack.add_pack(ref_name="right pack")
 
-        #self.multi_pack.remove_pack(index_of_pack=1)
-
-        self.data_pack10 = self.multi_pack.add_pack(ref_name="remove pack 10")
-        self.data_pack11 = self.multi_pack.add_pack(ref_name="remove pack 11")
-        self.data_pack12 = self.multi_pack.add_pack(ref_name="remove pack 12")
-
-        self.ref_id10 = self.multi_pack.get_pack_index(self.data_pack10.pack_id)
-        self.ref_id11 = self.multi_pack.get_pack_index(self.data_pack11.pack_id)
-        self.ref_id12 = self.multi_pack.get_pack_index(self.data_pack12.pack_id)
-
         self.data_pack1.pack_name = "some pack"
         self.data_pack1.set_text("This pack contains some sample data.")
 
         self.data_pack2.pack_name = "another pack"
         self.data_pack2.set_text("This pack contains some other sample data.")
-
-        self.data_pack10.pack_name = "the 1st pack for removing"
-        self.data_pack10.set_text("Test to see if we can delete the added pack for removing out of packgroup")
-
-        self.data_pack11.pack_name = "the 2nd pack for removing"
-        self.data_pack11.set_text("Test to see if we can delete the added pack for removing from packgroup")
-
-        self.data_pack12.pack_name = "the 3rd pack for removing"
-        self.data_pack12.set_text("Test to see if we can delete the added pack for removing from packgroup")
-
 
     def test_serialization(self):
         ser_str: str = self.multi_pack.to_string()
@@ -157,6 +137,12 @@ class DataPackTest(unittest.TestCase):
                 self.multi_pack.add_entry(
                     MultiPackLink(self.multi_pack, lt, rt)
                 )
+                # rt1 = right_tokens[key]
+                # tmp_mpl_1 = MultiPackLink(self.multi_pack, lt, rt)
+                # self.multi_pack.add_entry(
+                #     MultiPackLink(self.multi_pack, rt1, tmp_mpl_1)
+                # )
+
 
         # One way to link tokens.
         linked_tokens = []
@@ -218,62 +204,124 @@ class DataPackTest(unittest.TestCase):
             ],
         )
 
-    def test_remove_pack01(self):
-
-        """
-        Test to remove pack from multi pack group.
-        Returns:
-
-        """
-
-        self.multi_pack.remove_pack(1)
-        #self.assertNotIn(["remove pack 10"], self.multi_pack.pack_names)
-
     def test_remove_pack(self):
 
         """
-        Test to remove pack from multi pack group.
+        1. Test to remove the added pack from multi_pack which is independent;
+        2. Test to remove the added pack from multi_pack with MultiPackGroup and MultiPackLink;
+
         Returns:
 
         """
+
+        self.data_pack10 = self.multi_pack.add_pack(ref_name="remove pack 10")
+        self.data_pack11 = self.multi_pack.add_pack(ref_name="remove pack 11")
+        self.data_pack12 = self.multi_pack.add_pack(ref_name="remove pack 12")
+        self.data_pack13 = self.multi_pack.add_pack(ref_name="remove pack 13")
+
+        self.ref_id10 = self.multi_pack.get_pack_index(self.data_pack10.pack_id)
+        self.ref_id11 = self.multi_pack.get_pack_index(self.data_pack11.pack_id)
+        self.ref_id12 = self.multi_pack.get_pack_index(self.data_pack12.pack_id)
+        self.ref_id13 = self.multi_pack.get_pack_index(self.data_pack13.pack_id)
+
+        self.ref_id1 = self.multi_pack.get_pack_index(self.data_pack1.pack_id)
+        self.ref_id2 = self.multi_pack.get_pack_index(self.data_pack2.pack_id)
+
+        self.data_pack10.pack_name = "the 1st pack for removing"
+        self.data_pack10.set_text("Test to see if we can remove the added pack which is independent")
+
+        self.data_pack11.pack_name = "the 2nd pack for removing"
+        self.data_pack11.set_text("Test to see if we can remove the added pack from MultiPackGroup and MultiPackLink")
+
+        self.data_pack12.pack_name = "the 3rd pack for removing"
+        self.data_pack12.set_text("Test to see if we can remove the added pack from MultiPackGroup and MultiPackLink")
+
+        self.data_pack13.pack_name = "the 4th pack for removing"
+        self.data_pack13.set_text("Test to see if we can remove the added pack from MultiPackGroup and MultiPackLink")
+
+        # Add MultiPackLink to data_pack11 and data_pack12 & Add MultiPackGroup to data_pack11, data_pack12 and data_pack13
         # Add tokens to each pack.
-        for pack in self.multi_pack.packs[3:5]:
+        for pack in self.multi_pack.packs[self.ref_id11:self.ref_id12+1]:
             _space_token(pack)
 
         # Create some group.
         token: Annotation
 
-        romove_tokens_1 = {}
-        for token in self.multi_pack.packs[2].get(Token):
-            romove_tokens_1[token.text] = token
+        remove_tokens_11 = {}
+        for token in self.multi_pack.packs[self.ref_id11].get(Token):
+            remove_tokens_11[token.text] = token
 
-        romove_tokens_2 = {}
-        for token in self.multi_pack.packs[3].get(Token):
-            romove_tokens_2[token.text] = token
+        remove_tokens_12 = {}
+        for token in self.multi_pack.packs[self.ref_id12].get(Token):
+            remove_tokens_12[token.text] = token
 
-        romove_tokens_3 = {}
-        for token in self.multi_pack.packs[4].get(Token):
-            romove_tokens_3[token.text] = token
+        remove_tokens_13 = {}
+        for token in self.multi_pack.packs[self.ref_id13].get(Token):
+            remove_tokens_13[token.text] = token
 
-        for key, rt2 in romove_tokens_2.items():
-            if key in romove_tokens_3:
-                rt3 = romove_tokens_3[key]
+        for key, rt11 in remove_tokens_11.items():
+            if key in remove_tokens_12:
+                rt12 = remove_tokens_12[key]
+                tmp_mpk_entry = MultiPackLink(self.multi_pack, rt11, rt12)
                 self.multi_pack.add_entry(
-                    MultiPackGroup(self.multi_pack, [rt2, rt3])
+                    tmp_mpk_entry   # Add Multi Pack Link
                 )
-                self.multi_pack.add_entry(
-                    MultiPackLink(self.multi_pack, [rt2, rt3])
-                )
+                # my_rt12 = remove_tokens_12[key]
+                # tmp_mpk_entry2 = MultiPackLink(self.multi_pack, my_rt12, rt11)
+                # self.multi_pack.add_entry(
+                #     MultiPackLink(self.multi_pack, tmp_mpk_entry2, rt12) # Add Multi Pack Link to Link
+                # )
 
+                if key in remove_tokens_13:
+                    rt13 = remove_tokens_13[key]
+                    self.multi_pack.add_entry(
+                        MultiPackGroup(self.multi_pack, [rt11, rt12, rt13]) # Add Multi Pack Group of 3 packs
+                    )
+
+        self.check_list_id = [self.ref_id1,self.ref_id2,self.ref_id10,self.ref_id11,self.ref_id12,self.ref_id13]
+        self.check_list_name = self.multi_pack.pack_names
+        # print('check_list_id_all:', self.check_list_id)
+        # print('check_list_name_all:', self.check_list_name)
+
+        ## Preparation for remaining pack ID list check ##
+        self.expected_id_list_1 = list(set(self.check_list_id) - set([self.ref_id10]))
+        self.expected_id_list_2 = list(set(self.check_list_id) - set([self.ref_id10]) - set([self.ref_id11]))
+        self.expected_id_list_3 = list(set(self.check_list_id) - set([self.ref_id10]) - set([self.ref_id11]) - set([self.ref_id12]))
+        ## Preparation for remaining pack name list check ##
+        self.expected_name_list_1 = ['left pack', 'right pack', None, 'remove pack 11', 'remove pack 12', 'remove pack 13']
+        self.expected_name_list_2 = ['left pack', 'right pack', None, None, 'remove pack 12', 'remove pack 13']
+        self.expected_name_list_3 = ['left pack', 'right pack', None, None, None, 'remove pack 13']
+        self.expected_name_list_purge = ['left pack', 'right pack', 'remove pack 13']
+
+        # Test to remove the data_pack10 which is independent
         self.multi_pack.remove_pack(self.ref_id10)
+        ## remaining ref_id alignment check
+        self.remaining_id_1 = [self.ref_id1,self.ref_id2,self.ref_id11,self.ref_id12,self.ref_id13]
+        self.assertListEqual(self.expected_id_list_1, self.remaining_id_1)
+        ## remaining pack name alignment check
         self.assertNotIn(["remove pack 10"], self.multi_pack.pack_names)
+        self.assertListEqual(self.multi_pack.pack_names, self.expected_name_list_1)
 
+        # Test to remove the added pack from multi_pack with MultiPackGroup
         self.multi_pack.remove_pack(self.ref_id11, True)
+        ## remaining ref_id alignment check
+        self.remaining_id_2 = [self.ref_id1,self.ref_id2,self.ref_id12,self.ref_id13]
+        self.assertListEqual(self.expected_id_list_2, self.remaining_id_2)
+        ## remaining pack name alignment check
         self.assertNotIn(["remove pack 11"], self.multi_pack.pack_names)
+        self.assertListEqual(self.multi_pack.pack_names, self.expected_name_list_2)
 
+        # Test to remove the added pack from multi_pack with MultiPackGroup and MultiPackLink
         self.multi_pack.remove_pack(self.ref_id12, True)
+        ## remaining ref_id alignment check
+        self.remaining_id_3 = [self.ref_id1,self.ref_id2,self.ref_id13]
+        self.assertListEqual(self.expected_id_list_3, self.remaining_id_3)
+        ## remaining pack name alignment check
         self.assertNotIn(["remove pack 12"], self.multi_pack.pack_names)
+        self.assertListEqual(self.multi_pack.pack_names, self.expected_name_list_3)
 
+        self.multi_pack.purge_deleted_packs()
+        self.assertListEqual(self.multi_pack.pack_names, self.expected_name_list_purge)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/forte/data/multi_pack_test.py
+++ b/tests/forte/data/multi_pack_test.py
@@ -143,7 +143,6 @@ class DataPackTest(unittest.TestCase):
                 #     MultiPackLink(self.multi_pack, rt1, tmp_mpl_1)
                 # )
 
-
         # One way to link tokens.
         linked_tokens = []
         for link in self.multi_pack.all_links:
@@ -228,20 +227,29 @@ class DataPackTest(unittest.TestCase):
         self.ref_id2 = self.multi_pack.get_pack_index(self.data_pack2.pack_id)
 
         self.data_pack10.pack_name = "the 1st pack for removing"
-        self.data_pack10.set_text("Test to see if we can remove the added pack which is independent")
+        self.data_pack10.set_text(
+            "Test to see if we can remove the added pack which is independent"
+        )
 
         self.data_pack11.pack_name = "the 2nd pack for removing"
-        self.data_pack11.set_text("Test to see if we can remove the added pack from MultiPackGroup and MultiPackLink")
+        self.data_pack11.set_text(
+            "Test to see if we can remove the added pack from MultiPackGroup and MultiPackLink"
+        )
 
         self.data_pack12.pack_name = "the 3rd pack for removing"
-        self.data_pack12.set_text("Test to see if we can remove the added pack from MultiPackGroup and MultiPackLink")
+        self.data_pack12.set_text(
+            "Test to see if we can remove the added pack from MultiPackGroup and MultiPackLink"
+        )
 
         self.data_pack13.pack_name = "the 4th pack for removing"
-        self.data_pack13.set_text("Test to see if we can remove the added pack from MultiPackGroup and MultiPackLink")
+        self.data_pack13.set_text(
+            "Test to see if we can remove the added pack from MultiPackGroup and MultiPackLink"
+        )
 
-        # Add MultiPackLink to data_pack11 and data_pack12 & Add MultiPackGroup to data_pack11, data_pack12 and data_pack13
+        # Add MultiPackLink to data_pack11 and data_pack12 & Add MultiPackGroup to data_pack11, data_pack12
+        # and data_pack13
         # Add tokens to each pack.
-        for pack in self.multi_pack.packs[self.ref_id11:self.ref_id12+1]:
+        for pack in self.multi_pack.packs[self.ref_id11 : self.ref_id12 + 1]:
             _space_token(pack)
 
         # Create some group.
@@ -263,9 +271,7 @@ class DataPackTest(unittest.TestCase):
             if key in remove_tokens_12:
                 rt12 = remove_tokens_12[key]
                 tmp_mpk_entry = MultiPackLink(self.multi_pack, rt11, rt12)
-                self.multi_pack.add_entry(
-                    tmp_mpk_entry   # Add Multi Pack Link
-                )
+                self.multi_pack.add_entry(tmp_mpk_entry)  # Add Multi Pack Link
                 # my_rt12 = remove_tokens_12[key]
                 # tmp_mpk_entry2 = MultiPackLink(self.multi_pack, my_rt12, rt11)
                 # self.multi_pack.add_entry(
@@ -275,53 +281,118 @@ class DataPackTest(unittest.TestCase):
                 if key in remove_tokens_13:
                     rt13 = remove_tokens_13[key]
                     self.multi_pack.add_entry(
-                        MultiPackGroup(self.multi_pack, [rt11, rt12, rt13]) # Add Multi Pack Group of 3 packs
+                        MultiPackGroup(
+                            self.multi_pack, [rt11, rt12, rt13]
+                        )  # Add Multi Pack Group of 3 packs
                     )
 
-        self.check_list_id = [self.ref_id1,self.ref_id2,self.ref_id10,self.ref_id11,self.ref_id12,self.ref_id13]
+        self.check_list_id = [
+            self.ref_id1,
+            self.ref_id2,
+            self.ref_id10,
+            self.ref_id11,
+            self.ref_id12,
+            self.ref_id13,
+        ]
         self.check_list_name = self.multi_pack.pack_names
         # print('check_list_id_all:', self.check_list_id)
         # print('check_list_name_all:', self.check_list_name)
 
         ## Preparation for remaining pack ID list check ##
-        self.expected_id_list_1 = list(set(self.check_list_id) - set([self.ref_id10]))
-        self.expected_id_list_2 = list(set(self.check_list_id) - set([self.ref_id10]) - set([self.ref_id11]))
-        self.expected_id_list_3 = list(set(self.check_list_id) - set([self.ref_id10]) - set([self.ref_id11]) - set([self.ref_id12]))
+        self.expected_id_list_1 = list(
+            set(self.check_list_id) - set([self.ref_id10])
+        )
+        self.expected_id_list_2 = list(
+            set(self.check_list_id)
+            - set([self.ref_id10])
+            - set([self.ref_id11])
+        )
+        self.expected_id_list_3 = list(
+            set(self.check_list_id)
+            - set([self.ref_id10])
+            - set([self.ref_id11])
+            - set([self.ref_id12])
+        )
         ## Preparation for remaining pack name list check ##
-        self.expected_name_list_1 = ['left pack', 'right pack', None, 'remove pack 11', 'remove pack 12', 'remove pack 13']
-        self.expected_name_list_2 = ['left pack', 'right pack', None, None, 'remove pack 12', 'remove pack 13']
-        self.expected_name_list_3 = ['left pack', 'right pack', None, None, None, 'remove pack 13']
-        self.expected_name_list_purge = ['left pack', 'right pack', 'remove pack 13']
+        self.expected_name_list_1 = [
+            "left pack",
+            "right pack",
+            None,
+            "remove pack 11",
+            "remove pack 12",
+            "remove pack 13",
+        ]
+        self.expected_name_list_2 = [
+            "left pack",
+            "right pack",
+            None,
+            None,
+            "remove pack 12",
+            "remove pack 13",
+        ]
+        self.expected_name_list_3 = [
+            "left pack",
+            "right pack",
+            None,
+            None,
+            None,
+            "remove pack 13",
+        ]
+        self.expected_name_list_purge = [
+            "left pack",
+            "right pack",
+            "remove pack 13",
+        ]
 
         # Test to remove the data_pack10 which is independent
         self.multi_pack.remove_pack(self.ref_id10)
         ## remaining ref_id alignment check
-        self.remaining_id_1 = [self.ref_id1,self.ref_id2,self.ref_id11,self.ref_id12,self.ref_id13]
+        self.remaining_id_1 = [
+            self.ref_id1,
+            self.ref_id2,
+            self.ref_id11,
+            self.ref_id12,
+            self.ref_id13,
+        ]
         self.assertListEqual(self.expected_id_list_1, self.remaining_id_1)
         ## remaining pack name alignment check
         self.assertNotIn(["remove pack 10"], self.multi_pack.pack_names)
-        self.assertListEqual(self.multi_pack.pack_names, self.expected_name_list_1)
+        self.assertListEqual(
+            self.multi_pack.pack_names, self.expected_name_list_1
+        )
 
         # Test to remove the added pack from multi_pack with MultiPackGroup
         self.multi_pack.remove_pack(self.ref_id11, True)
         ## remaining ref_id alignment check
-        self.remaining_id_2 = [self.ref_id1,self.ref_id2,self.ref_id12,self.ref_id13]
+        self.remaining_id_2 = [
+            self.ref_id1,
+            self.ref_id2,
+            self.ref_id12,
+            self.ref_id13,
+        ]
         self.assertListEqual(self.expected_id_list_2, self.remaining_id_2)
         ## remaining pack name alignment check
         self.assertNotIn(["remove pack 11"], self.multi_pack.pack_names)
-        self.assertListEqual(self.multi_pack.pack_names, self.expected_name_list_2)
+        self.assertListEqual(
+            self.multi_pack.pack_names, self.expected_name_list_2
+        )
 
         # Test to remove the added pack from multi_pack with MultiPackGroup and MultiPackLink
         self.multi_pack.remove_pack(self.ref_id12, True)
         ## remaining ref_id alignment check
-        self.remaining_id_3 = [self.ref_id1,self.ref_id2,self.ref_id13]
+        self.remaining_id_3 = [self.ref_id1, self.ref_id2, self.ref_id13]
         self.assertListEqual(self.expected_id_list_3, self.remaining_id_3)
         ## remaining pack name alignment check
         self.assertNotIn(["remove pack 12"], self.multi_pack.pack_names)
-        self.assertListEqual(self.multi_pack.pack_names, self.expected_name_list_3)
+        self.assertListEqual(
+            self.multi_pack.pack_names, self.expected_name_list_3
+        )
 
         self.multi_pack.purge_deleted_packs()
-        self.assertListEqual(self.multi_pack.pack_names, self.expected_name_list_purge)
+        self.assertListEqual(
+            self.multi_pack.pack_names, self.expected_name_list_purge
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/forte/data/multi_pack_test.py
+++ b/tests/forte/data/multi_pack_test.py
@@ -31,11 +31,31 @@ class DataPackTest(unittest.TestCase):
         self.data_pack1 = self.multi_pack.add_pack(ref_name="left pack")
         self.data_pack2 = self.multi_pack.add_pack(ref_name="right pack")
 
+        #self.multi_pack.remove_pack(index_of_pack=1)
+
+        self.data_pack10 = self.multi_pack.add_pack(ref_name="remove pack 10")
+        self.data_pack11 = self.multi_pack.add_pack(ref_name="remove pack 11")
+        self.data_pack12 = self.multi_pack.add_pack(ref_name="remove pack 12")
+
+        self.ref_id10 = self.multi_pack.get_pack_index(self.data_pack10.pack_id)
+        self.ref_id11 = self.multi_pack.get_pack_index(self.data_pack11.pack_id)
+        self.ref_id12 = self.multi_pack.get_pack_index(self.data_pack12.pack_id)
+
         self.data_pack1.pack_name = "some pack"
         self.data_pack1.set_text("This pack contains some sample data.")
 
         self.data_pack2.pack_name = "another pack"
         self.data_pack2.set_text("This pack contains some other sample data.")
+
+        self.data_pack10.pack_name = "the 1st pack for removing"
+        self.data_pack10.set_text("Test to see if we can delete the added pack for removing out of packgroup")
+
+        self.data_pack11.pack_name = "the 2nd pack for removing"
+        self.data_pack11.set_text("Test to see if we can delete the added pack for removing from packgroup")
+
+        self.data_pack12.pack_name = "the 3rd pack for removing"
+        self.data_pack12.set_text("Test to see if we can delete the added pack for removing from packgroup")
+
 
     def test_serialization(self):
         ser_str: str = self.multi_pack.to_string()
@@ -197,6 +217,62 @@ class DataPackTest(unittest.TestCase):
                 ("data.", "data."),
             ],
         )
+
+    def test_remove_pack01(self):
+
+        """
+        Test to remove pack from multi pack group.
+        Returns:
+
+        """
+
+        self.multi_pack.remove_pack(1)
+        #self.assertNotIn(["remove pack 10"], self.multi_pack.pack_names)
+
+    def test_remove_pack(self):
+
+        """
+        Test to remove pack from multi pack group.
+        Returns:
+
+        """
+        # Add tokens to each pack.
+        for pack in self.multi_pack.packs[3:5]:
+            _space_token(pack)
+
+        # Create some group.
+        token: Annotation
+
+        romove_tokens_1 = {}
+        for token in self.multi_pack.packs[2].get(Token):
+            romove_tokens_1[token.text] = token
+
+        romove_tokens_2 = {}
+        for token in self.multi_pack.packs[3].get(Token):
+            romove_tokens_2[token.text] = token
+
+        romove_tokens_3 = {}
+        for token in self.multi_pack.packs[4].get(Token):
+            romove_tokens_3[token.text] = token
+
+        for key, rt2 in romove_tokens_2.items():
+            if key in romove_tokens_3:
+                rt3 = romove_tokens_3[key]
+                self.multi_pack.add_entry(
+                    MultiPackGroup(self.multi_pack, [rt2, rt3])
+                )
+                self.multi_pack.add_entry(
+                    MultiPackLink(self.multi_pack, [rt2, rt3])
+                )
+
+        self.multi_pack.remove_pack(self.ref_id10)
+        self.assertNotIn(["remove pack 10"], self.multi_pack.pack_names)
+
+        self.multi_pack.remove_pack(self.ref_id11, True)
+        self.assertNotIn(["remove pack 11"], self.multi_pack.pack_names)
+
+        self.multi_pack.remove_pack(self.ref_id12, True)
+        self.assertNotIn(["remove pack 12"], self.multi_pack.pack_names)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes [https://github.com/asyml/forte/issues/544]. 

### Description of changes
remove_pack(index_of_pack: int, clean_invalid_entries: bool = False) is added with clean_invalid_entries option for removing Cross-Pack links/groups associated with the data pack to be removed. If this flag is false and the pack to be removed have cross-pack links/groups, a ValueError will be raised indicate user the existence of cross pack links/groups with this pack and the need for setting the flag to be true to remove the associated links/groups.

### Possible influences of this PR.
Possible side-effects: if directly removed packs from related arrays the index for the elements after that will be changed which will affect those buffered index such as in getChild/getParent. So current solution is to set the element in corresponding arrays as None instead to keep the index of other elements unchanged. A purge function is also added however to compress the array and remove the None in it however this will cause the index of elements after those removed ones being changed.

### Test Conducted
Unit test performed for remove single pack, remove pack with cross pack links and groups. Also unit tested purge function.
