### PR TITLE
Fix pipeline.py and add documentation to the visualize example

### DIFF
--- a/examples/visualize/README.md
+++ b/examples/visualize/README.md
@@ -22,3 +22,17 @@ python visualize.py
 The visualization example looks like the following:
 
 ![visualization example](example_visualized.png)
+
+You may find a new folder named `Auto generated project` created under your working directory. This is the Stave project that is saved by [StaveProcessor](https://github.com/asyml/forte/blob/master/forte/processors/stave/stave_processor.py#L46). You can import this folder into the Stave backend database by running
+```bash
+stave -s import Auto\ generated\ project/
+```
+Note that you will be prompted to enter your username(admin) and password(admin) before moving forward.
+
+After it's saved to backend database, you can check out this project by starting a Stave server:
+```bash
+stave start -o
+```
+Again, you will need to log in with your username and password in order to view the project.
+
+For more instructions of how to use Stave command line tool, refer to https://github.com/asyml/stave/blob/master/README.md.


### PR DESCRIPTION
This PR fixes #557 

### Description of changes
- Add documentation to the visualize example
    - Instruction of how to save the generated visualization to Stave backend
- Fix some small issues in `pipeline.py`
    - Add `logger.error` in `_process_with_component()` to prevent the exception from being suppressed by `uvicorn` in remote service.
    - Add `hasattr` checking in `_remote_service_app.get_records()` and `_remote_service_app.get_expectation()`.
