### PR TITLE
Replaced incompatible package names for fortex.nltk

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ currently stored in two different repositories, as different projects.
   project and can be installed independently. *The project will be installed as
   `forte.xxx` and under `forte/xxx` folder in the site-packages.* For
   example, `forte.nltk` will be installed under `site_packages/forte/nltk` folder, and
-  the tool can be imported via `import forte.nltk` and uninstalled
+  the tool can be imported via `import fortex.nltk` and uninstalled
   via `pip uninstall forte.nltk`.
 
 ### Report Bugs

--- a/examples/blog_post_examples/pytorch_ecosystem.py
+++ b/examples/blog_post_examples/pytorch_ecosystem.py
@@ -14,12 +14,12 @@
 """
 Example code for pytorch blog post
 """
-from fortex.spacy import SpacyProcessor
 
 from forte.data.readers import HTMLReader
 from forte.pipeline import Pipeline
 from forte.data.data_pack import DataPack
 from forte.processors.stave import StaveProcessor
+from fortex.spacy import SpacyProcessor
 
 from ft.onto.base_ontology import Dependency
 from ftx.medical import MedicalEntityMention

--- a/examples/chatbot/chatbot_example.py
+++ b/examples/chatbot/chatbot_example.py
@@ -16,7 +16,6 @@ import yaml
 from termcolor import colored
 import torch
 
-from forte.nltk import NLTKSentenceSegmenter, NLTKWordTokenizer, NLTKPOSTagger
 from forte.common.configuration import Config
 from forte.data.multi_pack import MultiPack
 from forte.data.readers import MultiPackTerminalReader
@@ -26,6 +25,7 @@ from forte.processors.third_party import MicrosoftBingTranslator
 from forte.processors.nlp import SRLPredictor
 from forte.processors.ir import SearchProcessor, BertBasedQueryCreator
 from forte.data.selector import NameMatchSelector
+from fortex.nltk import NLTKSentenceSegmenter, NLTKWordTokenizer, NLTKPOSTagger
 from ft.onto.base_ontology import PredicateLink, Sentence
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/examples/clinical_pipeline/clinical_processing_pipeline.py
+++ b/examples/clinical_pipeline/clinical_processing_pipeline.py
@@ -5,7 +5,6 @@ import yaml
 from mimic3_note_reader import Mimic3DischargeNoteReader
 
 from forte.elastic import ElasticSearchPackIndexProcessor
-from forte.nltk import NLTKSentenceSegmenter
 from forte.hugginface.bio_ner_predictor import BioBERTNERPredictor
 from forte.hugginface.transformers_processor import BERTTokenizer
 
@@ -13,6 +12,7 @@ from forte.common.configuration import Config
 from forte.data.data_pack import DataPack
 from forte.pipeline import Pipeline
 from forte.processors.writers import PackIdJsonPackWriter
+from fortex.nltk import NLTKSentenceSegmenter
 
 
 def main(input_path: str, output_path: str, max_packs: int = -1):

--- a/examples/data_augmentation/data_select/data_select_and_augment_example.py
+++ b/examples/data_augmentation/data_select/data_select_and_augment_example.py
@@ -15,13 +15,13 @@ import argparse
 import logging
 import yaml
 
-from forte.nltk import NLTKWordTokenizer, NLTKPOSTagger
 from forte.data.multi_pack import MultiPack
 from forte.pipeline import Pipeline
 from forte.processors.base.data_selector_for_da import RandomDataSelector
 from forte.data.selector import AllPackSelector
 from forte.data.caster import MultiPackBoxer
 from forte.processors.data_augment import ReplacementDataAugmentProcessor
+from fortex.nltk import NLTKWordTokenizer, NLTKPOSTagger
 
 logging.root.setLevel(logging.INFO)
 

--- a/examples/pipelines/process_dataset_example.py
+++ b/examples/pipelines/process_dataset_example.py
@@ -22,7 +22,7 @@ from forte.data.data_pack import DataPack
 from forte.data.readers import PlainTextReader
 from forte.pipeline import Pipeline
 from forte.processors.nlp import CoNLLNERPredictor, SRLPredictor
-from forte.nltk import NLTKWordTokenizer, NLTKPOSTagger, NLTKSentenceSegmenter
+from fortex.nltk import NLTKWordTokenizer, NLTKPOSTagger, NLTKSentenceSegmenter
 from ft.onto.base_ontology import (
     Token,
     Sentence,

--- a/examples/pipelines/process_string_example.py
+++ b/examples/pipelines/process_string_example.py
@@ -21,7 +21,7 @@ from forte.data.data_pack import DataPack
 from forte.data.readers import StringReader
 from forte.pipeline import Pipeline
 from forte.processors.nlp import CoNLLNERPredictor, SRLPredictor
-from forte.nltk import NLTKWordTokenizer, NLTKPOSTagger, NLTKSentenceSegmenter
+from fortex.nltk import NLTKWordTokenizer, NLTKPOSTagger, NLTKSentenceSegmenter
 
 from ft.onto.base_ontology import (
     Token,

--- a/examples/serialization/serialize_example.py
+++ b/examples/serialization/serialize_example.py
@@ -22,8 +22,8 @@ from forte.data.readers import OntonotesReader, DirPackReader
 from forte.data.readers.deserialize_reader import MultiPackDirectoryReader
 from forte.pipeline import Pipeline
 from forte.processors.base import MultiPackProcessor, MultiPackWriter
-from forte.nltk import NLTKWordTokenizer, NLTKPOSTagger, NLTKSentenceSegmenter
 from forte.processors.writers import PackNameJsonPackWriter
+from fortex.nltk import NLTKWordTokenizer, NLTKPOSTagger, NLTKSentenceSegmenter
 from ft.onto.base_ontology import EntityMention, CrossDocEntityRelation
 
 


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/565. 

### Description of changes

- Replaced all examples which contain `import forte.nltk` to `import fortex.nltk`.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
