### PR TITLE
Add AudioAnnotation support to build_coverage_for

### DIFF
--- a/docs/data_pack.md
+++ b/docs/data_pack.md
@@ -1,0 +1,24 @@
+# DataPack Tutorial
+
+## Build Coverage Index
+`DataPack.get()` is commonly used to retrieve entries from a datapack. In some cases, we are only interested in getting entries from a specific range. `DataPack.get()` allows users to set `range_annotation` which controls the search area of the sub-types. If `DataPack.get()` is called frequently with queries related to the `range_annotation`, you may consider building the coverage index regarding the related entry types. Users can call `DataPack.build_coverage_for(context_type, covered_type)` in order to create a mapping between a pair of entry types and target entries that are covered in ranges specified by outer entries.
+
+For example, if you need to get all the `Token`s from some `Sentence`, you can write your code as:
+```python
+# Iterate through all the sentences in the pack.
+for sentence in input_pack.get(Sentence):
+    # Take all tokens from a sentence
+    token_entries = input_pack.get(
+        entry_type=Token, range_annotation=sentence
+    )
+```
+However, the snippet above may become a bottleneck if you have a lot of `Sentence` and `Token` entries inside the datapack. To speed up this process, you can build a coverage index first:
+```python
+# Build coverage index between `Token` and `Sentence`
+input_pack.build_coverage_for(
+    context_type=Sentence
+    covered_type=Token
+)
+```
+This `DataPack.build_coverage_for(context_type, covered_type)` function is able to build a mapping from `context_type` to `covered_type`, allowing faster retrieval of inner entries covered by outer entries inside the datapack.
+We also provide a function called `DataPack.covers(context_entry, covered_entry)` for coverage checking. It returns `True` if the span of `covered_entry` is covered by the span of `context_entry`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to Forte's documentation!
    examples.md
    ontology_generation.md
    audio_processing.md
+   data_pack.md
 
 API
 ====

--- a/forte/data/data_pack.py
+++ b/forte/data/data_pack.py
@@ -1099,7 +1099,9 @@ class DataPack(BasePack[Entry, Link, Group]):
         return a_dict
 
     def build_coverage_for(
-        self, context_type: Type[Annotation], covered_type: Type[EntryType]
+        self,
+        context_type: Type[Union[Annotation, AudioAnnotation]],
+        covered_type: Type[EntryType],
     ):
         """
         User can call this function to build coverage index for specific types.
@@ -1116,13 +1118,16 @@ class DataPack(BasePack[Entry, Link, Group]):
             self._index.build_coverage_index(self, context_type, covered_type)
 
     def covers(
-        self, context_entry: Annotation, covered_entry: EntryType
+        self,
+        context_entry: Union[Annotation, AudioAnnotation],
+        covered_entry: EntryType,
     ) -> bool:
         """
         Check if the `covered_entry` is covered (in span) of the `context_type`.
 
-        See :meth:`~forte.data.data_pack.DataIndex.in_span` for the definition
-         of `in span`.
+        See :meth:`~forte.data.data_pack.DataIndex.in_span` and
+        :meth:`~forte.data.data_pack.DataIndex.in_audio_span` for the definition
+        of `in span`.
 
         Args:
             context_entry: The context entry.
@@ -1136,18 +1141,26 @@ class DataPack(BasePack[Entry, Link, Group]):
         )
 
     def iter_in_range(
-        self, entry_type: Type[EntryType], range_annotation: Annotation
+        self,
+        entry_type: Type[EntryType],
+        range_annotation: Union[Annotation, AudioAnnotation],
     ) -> Iterator[EntryType]:
         """
         Iterate the entries of the provided type within or fulfill the
         constraints of the `range_annotation`. The constraint is True if
-        an entry is `in_span` of the provided `range_annotation`.
+        an entry is `in_span` or `in_audio_span` of the provided
+        `range_annotation`.
 
         Internally, if the coverage index between the entry type and the
         type of the `range_annotation` is built, then this will create the
         iterator from the index. Otherwise, the function will iterate them
         from scratch (which is slower). If there are frequent usage of this
         function, it is suggested to build the coverage index.
+
+        Only when `range_annotation` is an instance of `AudioAnnotation` will
+        the searching be performed on the list of audio annotations. In other
+        cases (i.e., when `range_annotation` is None or Annotation), it defaults
+        to a searching process on the list of text annotations.
 
         Args:
             entry_type: The type of entry to iterate over.
@@ -1167,30 +1180,54 @@ class DataPack(BasePack[Entry, Link, Group]):
             if coverage_index is None:
                 use_coverage = False
 
+        def get_bisect_range(entry_class, search_list: SortedList):
+            """
+            Perform binary search on the specified list for target entry class.
+
+            Args:
+                entry_class: Target type of entry. It can be Annotation or
+                    `AudioAnnotation`.
+                search_list: A `SortedList` object on which the binary search
+                    will be carried out.
+            """
+            range_begin = range_annotation.begin if range_annotation else 0
+            range_end = (
+                range_annotation.end
+                if range_annotation
+                else search_list[-1].end
+            )
+
+            temp_begin = entry_class(self, range_begin, range_begin)
+            begin_index = search_list.bisect(temp_begin)
+
+            temp_end = entry_class(self, range_end, range_end)
+            end_index = search_list.bisect(temp_end)
+
+            # Make sure these temporary annotations are not part of the
+            # actual data.
+            temp_begin.regret_creation()
+            temp_end.regret_creation()
+            return search_list[begin_index:end_index]
+
         if use_coverage and coverage_index is not None:
             for tid in coverage_index[range_annotation.tid]:
                 yield self.get_entry(tid)  # type: ignore
+        elif isinstance(range_annotation, AudioAnnotation):
+            if issubclass(entry_type, AudioAnnotation):
+                yield from get_bisect_range(
+                    AudioAnnotation, self.audio_annotations
+                )
+            elif issubclass(entry_type, Link):
+                for link in self.links:
+                    if self._index.in_audio_span(link, range_annotation.span):
+                        yield link
+            elif issubclass(entry_type, Group):
+                for group in self.groups:
+                    if self._index.in_audio_span(group, range_annotation.span):
+                        yield group
         else:
             if issubclass(entry_type, Annotation):
-                range_begin = range_annotation.begin if range_annotation else 0
-                range_end = (
-                    range_annotation.end
-                    if range_annotation
-                    else self.annotations[-1].end
-                )
-
-                if issubclass(entry_type, Annotation):
-                    temp_begin = Annotation(self, range_begin, range_begin)
-                    begin_index = self.annotations.bisect(temp_begin)
-
-                    temp_end = Annotation(self, range_end, range_end)
-                    end_index = self.annotations.bisect(temp_end)
-
-                    # Make sure these temporary annotations are not part of the
-                    # actual data.
-                    temp_begin.regret_creation()
-                    temp_end.regret_creation()
-                    yield from self.annotations[begin_index:end_index]
+                yield from get_bisect_range(Annotation, self.annotations)
             elif issubclass(entry_type, Link):
                 for link in self.links:
                     if self._index.in_span(link, range_annotation.span):
@@ -1223,7 +1260,10 @@ class DataPack(BasePack[Entry, Link, Group]):
         Annotation)` or :meth:`in_audio_span(E, range_annotation:
         AudioAnnotation)` returns True. If this function is called frequently
         with queries related to the `range_annotation`, please consider to build
-        the coverage index regarding the related entry types.
+        the coverage index regarding the related entry types. User can call
+        :meth:`build_coverage_for(context_type, covered_type)` in order to build
+        a mapping between a pair of entry types and target entries that are
+        covered in ranges specified by outer entries.
 
         The `components` list will filter the results by the `component` (i.e
         the creator of the entry). If `components` is provided, only the entries
@@ -1245,7 +1285,18 @@ class DataPack(BasePack[Entry, Link, Group]):
             In the above code snippet, we get entries of type ``Token`` within
             each ``sentence`` which were generated by ``NLTKTokenizer``. You
             can consider build coverage index between `Token` and `Sentence`
-            if this snippet is frequently used.
+            if this snippet is frequently used:
+
+                .. code-block:: python
+
+                    # Build coverage index between `Token` and `Sentence`
+                    input_pack.build_coverage_for(
+                        context_type=Sentence
+                        covered_type=Token
+                    )
+
+            After building the index from the snippet above, you will be able
+            to retrieve the tokens covered by sentence much faster.
 
         Args:
             entry_type (type): The type of entries requested.
@@ -1319,28 +1370,14 @@ class DataPack(BasePack[Entry, Link, Group]):
         entry_iter: Iterator[Entry]
         if issubclass(entry_type_, Generics):
             entry_iter = self.generics
-        elif isinstance(range_annotation, Annotation):
+        elif isinstance(range_annotation, (Annotation, AudioAnnotation)):
             if (
                 issubclass(entry_type_, Annotation)
                 or issubclass(entry_type_, Link)
                 or issubclass(entry_type_, Group)
+                or issubclass(entry_type_, AudioAnnotation)
             ):
                 entry_iter = self.iter_in_range(entry_type_, range_annotation)
-        elif isinstance(range_annotation, AudioAnnotation):
-            for entry_class, entry_list in (
-                (Link, self.links),
-                (Group, self.groups),
-                (AudioAnnotation, self.audio_annotations),
-            ):
-                if issubclass(entry_type_, entry_class):
-                    entry_iter = (
-                        entry
-                        for entry in entry_list
-                        if self._index.in_audio_span(
-                            entry, range_annotation.span
-                        )
-                    )
-                    break
         elif issubclass(entry_type_, Annotation):
             entry_iter = self.annotations
         elif issubclass(entry_type_, Link):
@@ -1404,7 +1441,8 @@ class DataIndex(BaseIndex):
     def __init__(self):
         super().__init__()
         self._coverage_index: Dict[
-            Tuple[Type[Annotation], Type[EntryType]], Dict[int, Set[int]]
+            Tuple[Type[Union[Annotation, AudioAnnotation]], Type[EntryType]],
+            Dict[int, Set[int]],
         ] = {}
         self._coverage_index_valid = True
 
@@ -1423,12 +1461,14 @@ class DataIndex(BaseIndex):
         self._coverage_index_valid = False
 
     def coverage_index(
-        self, outer_type: Type[Annotation], inner_type: Type[EntryType]
+        self,
+        outer_type: Type[Union[Annotation, AudioAnnotation]],
+        inner_type: Type[EntryType],
     ) -> Optional[Dict[int, Set[int]]]:
         r"""Get the coverage index from ``outer_type`` to ``inner_type``.
 
         Args:
-            outer_type (type): an annotation type.
+            outer_type (type): an annotation or `AudioAnnotation` type.
             inner_type (type): an entry type.
 
         Returns:
@@ -1442,7 +1482,7 @@ class DataIndex(BaseIndex):
     def get_covered(
         self,
         data_pack: DataPack,
-        context_annotation: Annotation,
+        context_annotation: Union[Annotation, AudioAnnotation],
         inner_type: Type[EntryType],
     ) -> Set[int]:
         """
@@ -1467,17 +1507,20 @@ class DataIndex(BaseIndex):
     def build_coverage_index(
         self,
         data_pack: DataPack,
-        outer_type: Type[Annotation],
+        outer_type: Type[Union[Annotation, AudioAnnotation]],
         inner_type: Type[EntryType],
     ):
         r"""Build the coverage index from ``outer_type`` to ``inner_type``.
 
         Args:
             data_pack (DataPack): The data pack to build coverage for.
-            outer_type (type): an annotation type.
-            inner_type (type): an entry type, can be Annotation, Link, Group.
+            outer_type (type): an annotation or `AudioAnnotation` type.
+            inner_type (type): an entry type, can be Annotation, Link, Group,
+                `AudioAnnotation`.
         """
-        if not isinstance(inner_type, (Annotation, Link, Group)):
+        if not issubclass(
+            inner_type, (Annotation, Link, Group, AudioAnnotation)
+        ):
             raise ValueError(f"Do not support coverage index for {inner_type}.")
 
         if not self.coverage_index_is_valid:
@@ -1492,7 +1535,7 @@ class DataIndex(BaseIndex):
         #  same.
         self._coverage_index[(outer_type, inner_type)] = {}
         for range_annotation in data_pack.get_entries_of(outer_type):
-            if isinstance(range_annotation, Annotation):
+            if isinstance(range_annotation, (Annotation, AudioAnnotation)):
                 entries = data_pack.get(inner_type, range_annotation)
                 entry_ids = {e.tid for e in entries}
                 self._coverage_index[(outer_type, inner_type)][
@@ -1502,37 +1545,54 @@ class DataIndex(BaseIndex):
         self.activate_coverage_index()
 
     def have_overlap(
-        self, entry1: Union[Annotation, int], entry2: Union[Annotation, int]
+        self,
+        entry1: Union[Annotation, int, AudioAnnotation],
+        entry2: Union[Annotation, int, AudioAnnotation],
     ) -> bool:
         r"""Check whether the two annotations have overlap in span.
 
         Args:
-            entry1 (str or Annotation): An :class:`Annotation` object to be
+            entry1 (int or Annotation or `AudioAnnotation`): An
+                :class:`Annotation` or :class:`AudioAnnotation` object to be
                 checked, or the tid of the Annotation.
-            entry2 (str or Annotation): Another :class:`Annotation` object to be
+            entry2 (int or Annotation or `AudioAnnotation`: Another
+                :class:`Annotation` or :class:`AudioAnnotation` object to be
                 checked, or the tid of the Annotation.
         """
-        entry1_: Annotation = (
+        entry1_: Union[Annotation, AudioAnnotation] = (
             self._entry_index[entry1]
             if isinstance(entry1, (int, np.integer))
             else entry1
         )
-        entry2_: Annotation = (
+        entry2_: Union[Annotation, AudioAnnotation] = (
             self._entry_index[entry2]
             if isinstance(entry2, (int, np.integer))
-            else entry1
+            else entry2
         )
 
-        if not isinstance(entry1_, Annotation):
+        if not isinstance(entry1_, (Annotation, AudioAnnotation)):
             raise TypeError(
-                f"'entry1' should be an instance of Annotation,"
+                f"'entry1' should be an instance of Annotation or `AudioAnnotation`,"
                 f" but get {type(entry1)}"
             )
 
-        if not isinstance(entry2_, Annotation):
+        if not isinstance(entry2_, (Annotation, AudioAnnotation)):
             raise TypeError(
-                f"'entry2' should be an instance of Annotation,"
+                f"'entry2' should be an instance of Annotation or `AudioAnnotation`,"
                 f" but get {type(entry2)}"
+            )
+
+        if (
+            isinstance(entry1_, Annotation)
+            and isinstance(entry2_, AudioAnnotation)
+        ) or (
+            isinstance(entry1_, AudioAnnotation)
+            and isinstance(entry2_, Annotation)
+        ):
+            raise TypeError(
+                "'entry1' and 'entry2' should be the same type of entry, "
+                f"but get type(entry1)={type(entry1_)}, "
+                f"typr(entry2)={type(entry2_)}"
             )
 
         return not (


### PR DESCRIPTION
This PR fixes #602 . 

### Description of changes
Add `AudioAnnotation` support to `DataPack.build_coverage_for`:
- class `DataIndex`: `have_overlap`, `build_coverage_index`, `get_covered`, `coverage_index`
  - Most changes are related to docstring and type annotations. Add logics related to type checking in `have_overlap`.
- class `DataPack`: `build_coverage_for`, `covers`, `get`, `iter_in_range`
  - Add more details of how to build a coverage index in the docstring of `get`
  - Refactor `iter_in_range` to support binary search on audio annotations
- A tutorial for DataPack usage is created. Right now it only includes guidelines about building coverage index.

### Test Conducted
`audio_annotation_test.py` is extended to include unit tests regarding the coverage index update.
