### PR TITLE
Import statements repaired for some examples

### DIFF
--- a/examples/clinical_pipeline/clinical_processing_pipeline.py
+++ b/examples/clinical_pipeline/clinical_processing_pipeline.py
@@ -4,16 +4,15 @@ import time
 import yaml
 from mimic3_note_reader import Mimic3DischargeNoteReader
 
-from forte.elastic import ElasticSearchPackIndexProcessor
-from forte.hugginface.bio_ner_predictor import BioBERTNERPredictor
-from forte.hugginface.transformers_processor import BERTTokenizer
-
 from forte.common.configuration import Config
 from forte.data.data_pack import DataPack
 from forte.pipeline import Pipeline
 from forte.processors.writers import PackIdJsonPackWriter
-from fortex.nltk import NLTKSentenceSegmenter
 
+from fortex.elastic import ElasticSearchPackIndexProcessor
+from fortex.hugginface.bio_ner_predictor import BioBERTNERPredictor
+from fortex.hugginface.transformers_processor import BERTTokenizer
+from fortex.nltk import NLTKSentenceSegmenter
 
 def main(input_path: str, output_path: str, max_packs: int = -1):
     pl = Pipeline[DataPack]()

--- a/examples/clinical_pipeline/utterance_searcher.py
+++ b/examples/clinical_pipeline/utterance_searcher.py
@@ -3,7 +3,7 @@ import logging
 import sqlite3
 from typing import Dict, Any, Optional, List
 
-from forte.elastic import ElasticSearchIndexer
+from fortex.elastic import ElasticSearchIndexer
 
 from forte.common import Resources, ProcessorConfigError
 from forte.common.configuration import Config

--- a/examples/data_augmentation/data_select/data_select_index_pipeline.py
+++ b/examples/data_augmentation/data_select/data_select_index_pipeline.py
@@ -26,8 +26,8 @@ This indexer is then used by the DataSelector class to search for documents.
 from typing import Dict, Any
 import logging
 
-from forte.elastic import ElasticSearchIndexer
-from forte.elastic import ElasticSearchPackIndexProcessor
+from fortex.elastic import ElasticSearchIndexer
+from fortex.elastic import ElasticSearchPackIndexProcessor
 
 from forte.common.configuration import Config
 from forte.data.data_pack import DataPack

--- a/examples/passage_ranker/create_index.py
+++ b/examples/passage_ranker/create_index.py
@@ -18,7 +18,7 @@ import os
 
 import yaml
 
-from forte.elastic import ElasticSearchTextIndexProcessor
+from fortex.elastic import ElasticSearchTextIndexProcessor
 
 from forte.common.configuration import Config
 from forte.data.data_pack import DataPack

--- a/examples/passage_ranker/indexer_reranker_eval_pipeline.py
+++ b/examples/passage_ranker/indexer_reranker_eval_pipeline.py
@@ -16,7 +16,7 @@ import argparse
 
 import yaml
 
-from forte.elastic import ElasticSearchQueryCreator, ElasticSearchProcessor
+from fortex.elastic import ElasticSearchQueryCreator, ElasticSearchProcessor
 
 from ms_marco_evaluator import MSMarcoEvaluator
 from reader import EvalReader

--- a/examples/passage_ranker/indexer_reranker_inference_pipeline.py
+++ b/examples/passage_ranker/indexer_reranker_inference_pipeline.py
@@ -17,7 +17,7 @@ import os
 import yaml
 from termcolor import colored
 
-from forte.elastic import ElasticSearchQueryCreator, ElasticSearchProcessor
+from fortex.elastic import ElasticSearchQueryCreator, ElasticSearchProcessor
 
 from forte.common.configuration import Config
 from forte.data.multi_pack import MultiPack

--- a/examples/visualize/visualize.py
+++ b/examples/visualize/visualize.py
@@ -1,5 +1,5 @@
-from forte.huggingface import ZeroShotClassifier
-from forte.stanza import StandfordNLPProcessor
+from fortex.huggingface import ZeroShotClassifier
+from fortex.stanza import StandfordNLPProcessor
 
 from forte import Pipeline
 from forte.data.readers import TerminalReader


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/623

### Description of changes
Import statements for packages like forte.huggingface, forte.elastic, etc were repaired
eg, 
`import forte.hugginface` changed to `import forte.huggingface`
`import forte.elastic` changed to `import forte.elastic`

### Possible influences of this PR.
Should allow executing some of our examples without throwing `ModuleNotFoundError`
