### PR TITLE
Fix package not found issue 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     license="Apache License Version 2.0",
     packages=setuptools.find_namespace_packages(
-        include=['ft.*', 'ftx.*'],
-        exclude=["scripts*", "examples*", "tests*"]
+        include=['ft.*', 'ftx.*', 'forte']
     ),
     include_package_data=True,
     platforms="any",


### PR DESCRIPTION
This PR fixes #658 . 

### Description of changes
Append 'forte' to `include` and remove the `exclude` argument for `find_namespace_packages` in setup.py.

### Test Conducted
Go through the steps in `To Reproduce` section in #658 and see if the bug still exists.
