### PR TITLE
Fix maybe_download issue

### DIFF
--- a/forte/data/data_utils.py
+++ b/forte/data/data_utils.py
@@ -20,6 +20,7 @@ import sys
 import tarfile
 import urllib.request
 import zipfile
+import re
 from typing import List, Optional, overload, Union
 
 from forte.utils.types import PathLike
@@ -178,6 +179,13 @@ def _download_from_google_drive(
         for key, value in response.cookies.items():
             if key.startswith("download_warning"):
                 return value
+        if "Google Drive - Virus scan warning" in response.text:
+            match = re.search("confirm=([0-9A-Za-z_]+)", response.text)
+            if match is None or len(match.groups()) < 1:
+                raise ValueError(
+                    "No token found in warning page from Google Drive."
+                )
+            return match.groups()[0]
         return None
 
     file_id = _extract_google_drive_file_id(url)


### PR DESCRIPTION
This PR fixes #672. #672 might be caused by a recent update in Google API. Previously, when google drive responds with a warning page, `maybe_download()` is able to retrieve token info from a key starting with `"download_warning"` stored in cookies of the response. The token will be used to prepare a second request, which will download the actual large file (for details, refer to https://stackoverflow.com/a/39225039). However, recently we cannot find the token from the cookies, thus it fails to recognize the warning page.

### Description of changes
We propose a workaround based on this [post](https://stackoverflow.com/a/48238689), which extracts the token from a `"confirm=([0-9A-Za-z_]+)"` pattern found in the warning page.

### Test Conducted
Go through the steps in `To Reproduce` section from #672 and see if the bug still exists. More google drive urls for testing:
* https://drive.google.com/file/d/1Nh7D6Xam5JefdoSXRoL7S0DZK1d4i2UK/view?usp=sharing - 413M
* https://drive.google.com/file/d/1crlASTMlsihALlkabAQP6JTYIZwC1Wm8/view - 3.4G
