### PR TITLE
jinja2 3.1.0 is incompatible so downgrade is needed

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -43,3 +43,4 @@ fastapi==0.65.2
 uvicorn==0.14.0
 
 nbsphinx==0.8.8
+jinja2<=3.0.3


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/699. 

The latest update on `jinja2==3.1.0` removed `environmentfilter` which is needed.


### Description of changes
* Add restrictions on `jinja2` version to `<=3.0.3`
 

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
