### PR TITLE
Split the pypi workflow and single-source the version

### DIFF
--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,6 +1,9 @@
 name: PYPI
 
 on:
+  push: 
+    tags:
+      - v*
   # Trigger this workflow manually from the Actions tab
   workflow_dispatch:
   
@@ -24,8 +27,9 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: |
           python -m build --sdist --wheel --outdir dist/ .
-      - name: Publish Python 🐍 distributions 📦 to PyPI
+      - name: Publish Python 🐍 distributions 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import os
 
 import setuptools
 
@@ -8,9 +9,15 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 if sys.version_info < (3, 6):
     sys.exit("Python>=3.6 is required by Forte.")
 
+version = {}
+with open(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "forte/version.py"
+)) as fp:
+    exec(fp.read(), version)
+
 setuptools.setup(
     name="forte",
-    version="0.1.2",
+    version=version["VERSION"],
     url="https://github.com/asyml/forte",
     description="Forte is extensible framework for building composable and "
     "modularized NLP workflows.",


### PR DESCRIPTION
### Description of changes
Split `pypi.yml` into two workflows:
* `testpypi.yml`: Triggered by a new tag/release or manually.
* `pypi.yml`: Can only be triggered mannually.

Single-sourcing the package version:
* `setup.py` will read forte version from `forte/version.py`.
* reference: https://packaging.python.org/en/latest/guides/single-sourcing-package-version/

### Possible influences of this PR.
A new release/tag will no longer automatically upload the package to PyPi. It will only push the repo to TestPyPi.

### Test Conducted
This PR can be tested by updating `version.py` and then triggering the testpypi/pypi workflow. We can check the version of the package uploaded to testpypi/pypi.
