### PR TITLE
add get_subtypes and get_class in DataStore; cache is_subtype.

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -135,6 +135,7 @@ docstrings
 numpy
 crowdworkers
 subtype
+subtypes
 subword
 wikipedia
 stopword

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -30,6 +30,7 @@ class DataStore(BaseStore):
     # TODO: temporarily disable this for development purposes.
     # pylint: disable=pointless-string-statement
     _type_attributes: dict = {}
+    _get_subtype_cache: dict = {}
     enable_cache = True
 
     def __init__(
@@ -259,6 +260,7 @@ class DataStore(BaseStore):
             "parent_class": set(),
         }
         DataStore._type_attributes[type_name] = new_entry_info
+        DataStore.enable_cache = False
 
         return new_entry_info
 
@@ -967,11 +969,21 @@ class DataStore(BaseStore):
         Returns:
             A list of subtypes.
         """
+        if DataStore.enable_cache:
+            try:
+                return DataStore._get_subtype_cache[type_name]
+            except:
+                pass
+
         cls = DataStore.get_class(type_name)
         subtypes = []
         for subtype in DataStore._type_attributes:
             if DataStore._is_subclass(subtype, cls):
                 subtypes.append(subtype)
+        subtypes.sort()
+        DataStore.enable_cache = True
+        DataStore._get_subtype_cache[type_name] = subtypes
+
         return subtypes
 
     @staticmethod

--- a/tests/forte/data/data_store_test.py
+++ b/tests/forte/data/data_store_test.py
@@ -152,6 +152,18 @@ class DataStoreTest(unittest.TestCase):
                 },
                 "parent_class": set(),
             },
+            "ft.onto.base_ontology.Phrase": {
+                "attributes": {
+                    "predicate_lemma": 4,
+                    "framenet_id": 5,
+                    "is_verb": 6,
+                },
+                "parent_class": set(),
+            },
+            "forte.data.ontology.core.Entry": {
+                "attributes": {},
+                "parent_class": set(),
+            }
         }
         # The order is [Document, Sentence]. Initialize 2 entries in each list.
         # Document entries have tid 1234, 3456.
@@ -500,7 +512,7 @@ class DataStoreTest(unittest.TestCase):
         self.data_store.add_annotation_raw("ft.onto.base_ontology.EntityMention", 10, 12)
         num_phrase = len(self.data_store._DataStore__elements["ft.onto.base_ontology.EntityMention"])
         self.assertEqual(num_phrase, 1)
-        self.assertEqual(len(DataStore._type_attributes), 3)
+        self.assertEqual(len(DataStore._type_attributes), 5)
         self.assertEqual(len(self.data_store._DataStore__entry_dict), 8)
 
     def test_get_attribute(self):
@@ -776,6 +788,13 @@ class DataStoreTest(unittest.TestCase):
                 "ft.onto.base_ontology.Title", forte.data.ontology.top.Link
             )
         )
+    
+    def test_get_subtypes(self):
+        with self.assertRaises(ValueError):
+            DataStore.get_subtypes("ft.onto.base_ontology.EntityMention")
+        entry_subtypes = DataStore.get_subtypes("forte.data.ontology.core.Entry")
+        self.assertEqual(len(entry_subtypes), 4)
+        self.assertListEqual(entry_subtypes, ['ft.onto.base_ontology.Document', 'ft.onto.base_ontology.Sentence', 'ft.onto.base_ontology.Phrase', 'forte.data.ontology.core.Entry'])
 
 
 if __name__ == "__main__":

--- a/tests/forte/data/data_store_test.py
+++ b/tests/forte/data/data_store_test.py
@@ -794,8 +794,16 @@ class DataStoreTest(unittest.TestCase):
             DataStore.get_subtypes("ft.onto.base_ontology.EntityMention")
         entry_subtypes = DataStore.get_subtypes("forte.data.ontology.core.Entry")
         self.assertEqual(len(entry_subtypes), 4)
-        self.assertListEqual(entry_subtypes, ['ft.onto.base_ontology.Document', 'ft.onto.base_ontology.Sentence', 'ft.onto.base_ontology.Phrase', 'forte.data.ontology.core.Entry'])
-
+        self.assertListEqual(entry_subtypes, ['forte.data.ontology.core.Entry', 'ft.onto.base_ontology.Document', 'ft.onto.base_ontology.Phrase', 'ft.onto.base_ontology.Sentence'])
+        entry_subtypes = DataStore.get_subtypes("ft.onto.base_ontology.Document")
+        self.assertListEqual(entry_subtypes, ['ft.onto.base_ontology.Document'])
+        # test cache
+        entry_subtypes = DataStore.get_subtypes("forte.data.ontology.core.Entry")
+        self.assertListEqual(entry_subtypes, ['forte.data.ontology.core.Entry', 'ft.onto.base_ontology.Document', 'ft.onto.base_ontology.Phrase', 'ft.onto.base_ontology.Sentence'])
+        # test cache change
+        self.data_store._get_type_info("ft.onto.base_ontology.Subword")
+        entry_subtypes = DataStore.get_subtypes("forte.data.ontology.core.Entry")
+        self.assertListEqual(entry_subtypes, ['forte.data.ontology.core.Entry', 'ft.onto.base_ontology.Document', 'ft.onto.base_ontology.Phrase', 'ft.onto.base_ontology.Sentence', 'ft.onto.base_ontology.Subword'])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes #765. 

### Description of changes
Add function `get_subtypes` in DataStore. Implemented a wrapper for `get_class` for DataStore class. 
Since `get_subtypes` return value is prone to change, I add cache to `is_subtype` instead.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
