### PR TITLE
add fastapi upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         ],
         "ir": ["texar-pytorch>=0.1.4", "tensorflow>=1.15.0"],
         "remote": [
-            "fastapi>=0.65.2",
+            "fastapi>=0.65.2, <=0.75.2",
             "uvicorn>=0.14.0",
         ],
         "audio_ext": ["soundfile>=0.10.3"],


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/776. 

### Description of changes
* add a version upper bound `0.75.2` for fastapi 

### Possible influences of this PR.
* it will unblock the CI test.

### Test Conducted
Describe what test cases are included for the PR.
