### PR TITLE
Initialize new entry attribute list with default values

### DIFF
--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -12,11 +12,11 @@
 # limitations under the License.
 
 from typing import Dict, List, Iterator, Tuple, Optional, Any
-from typing_inspect import get_origin
 import uuid
 from bisect import bisect_left
 from heapq import heappush, heappop
 from sortedcontainers import SortedList
+from typing_inspect import get_origin
 
 from forte.utils import get_class
 from forte.data.base_store import BaseStore

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -338,9 +338,9 @@ class DataStore(BaseStore):
         attr_list: List = [None] * len(attr_dict)
         for attr_name, attr_id in attr_dict.items():
             attr_class = get_origin(attr_fields[attr_name].type)
-            if attr_class in (FList, list):
+            if attr_class in (FList, list, List):
                 attr_list[attr_id - constants.ATTR_BEGIN_INDEX] = []
-            elif attr_class in (FDict, dict):
+            elif attr_class in (FDict, dict, Dict):
                 attr_list[attr_id - constants.ATTR_BEGIN_INDEX] = {}
         return attr_list
 

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from typing import Dict, List, Iterator, Tuple, Optional, Any
+from typing_inspect import get_origin
 import uuid
 from bisect import bisect_left
 from heapq import heappush, heappop
@@ -19,6 +20,7 @@ from sortedcontainers import SortedList
 
 from forte.utils import get_class
 from forte.data.base_store import BaseStore
+from forte.data.ontology.core import FList, FDict
 from forte.data.ontology.top import Annotation, AudioAnnotation
 from forte.common import constants
 from forte.utils.utils import get_full_module_name
@@ -318,18 +320,32 @@ class DataStore(BaseStore):
         """
         return self._get_type_info(type_name)["parent_class"]
 
-    def _num_attributes_for_type(self, type_name: str) -> int:
-        """Get the length of the attribute dict of an entry type.
+    def _default_attributes_for_type(self, type_name: str) -> List:
+        """Get a list of attributes of an entry type with their default values.
+        If an attribute is annotated with `FList` or `List`, then the default
+        value is an empty list `[]`. When an attribute is annotated with `FDict`
+        or `Dict` then the default value will be an empty dictionary `{}`. For
+        all other cases (including primitive types, Union, NoneType, etc.) the
+        default value will be set to `None`.
+
         Args:
             type_name (str): The fully qualified type name of the new entry.
         Returns:
-            attr_dict (dict): The attributes-to-index dict of an entry.
+            attr_dict (list): A list of attributes with default values.
         """
-        return len(self._get_type_attribute_dict(type_name))
+        attr_dict: Dict = self._get_type_attribute_dict(type_name)
+        attr_fields: Dict = self._get_entry_attributes_by_class(type_name)
+        attr_list: List = [None] * len(attr_dict)
+        for attr_name, attr_id in attr_dict.items():
+            attr_class = get_origin(attr_fields[attr_name].type)
+            if attr_class in (FList, list):
+                attr_list[attr_id - constants.ATTR_BEGIN_INDEX] = []
+            elif attr_class in (FDict, dict):
+                attr_list[attr_id - constants.ATTR_BEGIN_INDEX] = {}
+        return attr_list
 
     def _new_annotation(self, type_name: str, begin: int, end: int) -> List:
         r"""This function generates a new annotation with default fields.
-        All default fields are filled with None.
         Called by add_annotation_raw() to create a new annotation with
         ``type_name``, ``begin``, and ``end``.
 
@@ -346,15 +362,14 @@ class DataStore(BaseStore):
         entry: List[Any]
 
         entry = [begin, end, tid, type_name]
-        entry += self._num_attributes_for_type(type_name) * [None]
+        entry += self._default_attributes_for_type(type_name)
 
         return entry
 
     def _new_link(
         self, type_name: str, parent_tid: int, child_tid: int
     ) -> List:
-        r"""This function generates a new link with default fields. All
-        default fields are filled with None.
+        r"""This function generates a new link with default fields.
         Called by add_link_raw() to create a new link with ``type_name``,
         ``parent_tid``, and ``child_tid``.
 
@@ -371,13 +386,12 @@ class DataStore(BaseStore):
         entry: List[Any]
 
         entry = [parent_tid, child_tid, tid, type_name]
-        entry += self._num_attributes_for_type(type_name) * [None]
+        entry += self._default_attributes_for_type(type_name)
 
         return entry
 
     def _new_group(self, type_name: str, member_type: str) -> List:
-        r"""This function generates a new group with default fields. All
-        default fields are filled with None.
+        r"""This function generates a new group with default fields.
         Called by add_group_raw() to create a new group with
         ``type_name`` and ``member_type``.
 
@@ -392,7 +406,7 @@ class DataStore(BaseStore):
         tid: int = self._new_tid()
 
         entry = [member_type, [], tid, type_name]
-        entry += self._num_attributes_for_type(type_name) * [None]
+        entry += self._default_attributes_for_type(type_name)
 
         return entry
 
@@ -1019,7 +1033,7 @@ class DataStore(BaseStore):
         raise NotImplementedError
 
     @staticmethod
-    def _get_entry_attributes_by_class(input_entry_class_name: str) -> List:
+    def _get_entry_attributes_by_class(input_entry_class_name: str) -> Dict:
         """Get type attributes by class name. `input_entry_class_name` should be
         a fully qualified name of an entry class.
 
@@ -1038,7 +1052,8 @@ class DataStore(BaseStore):
             input_entry_class_name: A fully qualified name of an entry class.
 
         Returns:
-            A list of attributes corresponding to the input class.
+            A dictionary of attributes with their field information
+            corresponding to the input class.
 
         For example, for Sentence we want to get a list of
         ["speaker", "part_id", "sentiment", "classification", "classifications"].
@@ -1050,7 +1065,7 @@ class DataStore(BaseStore):
             entry_name = "ft.onto.base_ontology.Sentence"
 
             # function signature
-            get_entry_attributes_by_class(entry_name)
+            list(get_entry_attributes_by_class(entry_name))
 
             # return
             # ["speaker", "part_id", "sentiment", "classification", "classifications"]
@@ -1058,6 +1073,6 @@ class DataStore(BaseStore):
         """
         class_ = get_class(input_entry_class_name)
         try:
-            return list(class_.__dataclass_fields__.keys())
+            return class_.__dataclass_fields__
         except AttributeError:
-            return []
+            return {}

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -337,6 +337,8 @@ class DataStore(BaseStore):
         attr_fields: Dict = self._get_entry_attributes_by_class(type_name)
         attr_list: List = [None] * len(attr_dict)
         for attr_name, attr_id in attr_dict.items():
+            # TODO: We should keep a record of the attribute class instead of
+            # inspecting the class on the fly.
             attr_class = get_origin(attr_fields[attr_name].type)
             if attr_class in (FList, list, List):
                 attr_list[attr_id - constants.ATTR_BEGIN_INDEX] = []

--- a/tests/forte/data/data_store_test.py
+++ b/tests/forte/data/data_store_test.py
@@ -481,11 +481,11 @@ class DataStoreTest(unittest.TestCase):
 
     def test_add_annotation_raw(self):
         # test add Document entry
-        self.data_store.add_annotation_raw(
+        tid_doc: int = self.data_store.add_annotation_raw(
             "ft.onto.base_ontology.Document", 1, 5
         )
         # test add Sentence entry
-        self.data_store.add_annotation_raw(
+        tid_sent: int = self.data_store.add_annotation_raw(
             "ft.onto.base_ontology.Sentence", 5, 8
         )
         num_doc = len(
@@ -502,9 +502,16 @@ class DataStoreTest(unittest.TestCase):
         self.assertEqual(num_doc, 3)
         self.assertEqual(num_sent, 3)
         self.assertEqual(len(self.data_store._DataStore__tid_ref_dict), 7)
+        self.assertEqual(self.data_store.get_entry(tid=tid_doc)[0], [
+            1, 5, tid_doc, "ft.onto.base_ontology.Document", [], {}, {}
+        ])
+        self.assertEqual(self.data_store.get_entry(tid=tid_sent)[0], [
+            5, 8, tid_sent, "ft.onto.base_ontology.Sentence",
+            None, None, {}, {}, {}
+        ])
 
         # test add new annotation type
-        self.data_store.add_annotation_raw(
+        tid_em: int = self.data_store.add_annotation_raw(
             "ft.onto.base_ontology.EntityMention", 10, 12
         )
         num_phrase = len(
@@ -515,6 +522,9 @@ class DataStoreTest(unittest.TestCase):
         self.assertEqual(num_phrase, 1)
         self.assertEqual(len(DataStore._type_attributes), 3)
         self.assertEqual(len(self.data_store._DataStore__tid_ref_dict), 8)
+        self.assertEqual(self.data_store.get_entry(tid=tid_em)[0], [
+            10, 12, tid_em, "ft.onto.base_ontology.EntityMention", None
+        ])
 
     def test_get_attribute(self):
         speaker = self.data_store.get_attribute(9999, "speaker")
@@ -785,8 +795,8 @@ class DataStoreTest(unittest.TestCase):
             ],
         }
         for entry_name in entry_name_attributes_dict.keys():
-            attribute_result = self.data_store._get_entry_attributes_by_class(
-                entry_name
+            attribute_result = list(
+                self.data_store._get_entry_attributes_by_class(entry_name)
             )
             self.assertEqual(
                 attribute_result, entry_name_attributes_dict[entry_name]


### PR DESCRIPTION
This PR fixes #786. 

### Description of changes
* In `DataStore._new_annotaion()`, `DataStore._new_link()` and `DataStore._new_group()`,  each attribute will be initialized based on its typing annotation.
  * FDict, Dict -> {}
  * FList, List -> []
  * other types (premitives, Union, NoneType, etc.) -> None

### Test Conducted
`test_add_annotation_raw()` is updated to validate this new initialization behavior.
