### PR TITLE
Check duplicates when adding new annotation to DataStore

### DIFF
--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -567,8 +567,9 @@ class DataStore(BaseStore):
             tid: ``tid`` of the Annotation entry that is being added.
                 It's optional, and it will be
                 auto-assigned if not given.
-            allow_duplicate: Whether we allow duplicate in the DataStore.
-                Default value is True.
+            allow_duplicate: Whether we allow duplicate in the DataStore. When
+                it's set to True, the function will return the tid of existing
+                entry if a duplicate is found. Default value is True.
 
         Returns:
             ``tid`` of the entry.

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -568,7 +568,7 @@ class DataStore(BaseStore):
                 It's optional, and it will be
                 auto-assigned if not given.
             allow_duplicate: Whether we allow duplicate in the DataStore. When
-                it's set to True, the function will return the tid of existing
+                it's set to False, the function will return the tid of existing
                 entry if a duplicate is found. Default value is True.
 
         Returns:

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -568,8 +568,8 @@ class DataStore(BaseStore):
                 It's optional, and it will be
                 auto-assigned if not given.
             allow_duplicate: Whether we allow duplicate in the DataStore. When
-                it's set to False, the function will return the tid of existing
-                entry if a duplicate is found. Default value is True.
+                it's set to False, the function will return the ``tid`` of
+                existing entry if a duplicate is found. Default value is True.
 
         Returns:
             ``tid`` of the entry.

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -14,7 +14,6 @@
 
 from typing import Dict, List, Iterator, Tuple, Optional, Any, Type
 import uuid
-from bisect import bisect_left
 from heapq import heappush, heappop
 from sortedcontainers import SortedList
 from typing_inspect import get_origin
@@ -549,7 +548,12 @@ class DataStore(BaseStore):
             raise KeyError(f"Entry with tid {tid} not found.")
 
     def add_annotation_raw(
-        self, type_name: str, begin: int, end: int, tid: Optional[int] = None
+        self,
+        type_name: str,
+        begin: int,
+        end: int,
+        tid: Optional[int] = None,
+        allow_duplicate: bool = True,
     ) -> int:
 
         r"""This function adds an annotation entry with ``begin`` and ``end``
@@ -563,6 +567,8 @@ class DataStore(BaseStore):
             tid: ``tid`` of the Annotation entry that is being added.
                 It's optional, and it will be
                 auto-assigned if not given.
+            allow_duplicate: Whether we allow duplicate in the DataStore.
+                Default value is True.
 
         Returns:
             ``tid`` of the entry.
@@ -574,6 +580,16 @@ class DataStore(BaseStore):
         # A reference to the entry should be store in both self.__elements and
         # self.__tid_ref_dict.
         entry = self._new_annotation(type_name, begin, end, tid)
+        if not allow_duplicate and type_name in self.__elements:
+            # Return the tid of existing entry if duplicate is not allowed
+            index = self.__elements[type_name].bisect_left(entry)
+            target_entry = self.__elements[type_name][index]
+            if (
+                target_entry[constants.BEGIN_INDEX] == begin
+                and target_entry[constants.END_INDEX] == end
+            ):
+                return target_entry[constants.TID_INDEX]
+
         return self._add_entry_raw(Annotation, type_name, entry)
 
     def add_link_raw(
@@ -735,7 +751,13 @@ class DataStore(BaseStore):
         # complexity: O(lgn)
         # if it's annotation type, use bisect to find the index
         if self._is_annotation(type_name):
-            entry_index = bisect_left(target_list, entry_data)
+            try:
+                entry_index = target_list.index(entry_data)
+            except ValueError as e:
+                raise RuntimeError(
+                    f"When deleting entry [{tid}], entry data is not found in"
+                    f"the target list of [{type_name}]."
+                ) from e
         else:  # if it's group or link, use the index in entry_list
             entry_index = entry_data[constants.ENTRY_DICT_ENTRY_INDEX]
 
@@ -837,7 +859,12 @@ class DataStore(BaseStore):
         index_id = -1
         if self._is_annotation_tid(tid):
             entry_list = self.__elements[entry_type]
-            index_id = entry_list.bisect_left(entry)
+            try:
+                index_id = entry_list.index(entry)
+            except ValueError as e:
+                raise ValueError(
+                    f"Entry {entry} not found in entry list."
+                ) from e
             if (not 0 <= index_id < len(entry_list)) or (
                 entry_list[index_id][constants.TID_INDEX]
                 != entry[constants.TID_INDEX]

--- a/tests/forte/data/data_store_test.py
+++ b/tests/forte/data/data_store_test.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from forte.data.data_store import DataStore
 from forte.data.ontology.top import Annotation, Generics
 from forte.data.data_pack import DataPack
+from forte.common import constants
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -163,18 +164,18 @@ class DataStoreTest(unittest.TestCase):
             5,
             1234,
             "ft.onto.base_ontology.Document",
-            None,
-            "Postive",
-            None,
+            [],
+            {"Postive": 0},
+            {},
         ]
         ref2 = [
             10,
             25,
             3456,
             "ft.onto.base_ontology.Document",
-            "Doc class A",
-            "Negative",
-            "Class B",
+            ["Doc class A"],
+            {"Negative": 0},
+            {},
         ]
         ref3 = [
             6,
@@ -183,9 +184,9 @@ class DataStoreTest(unittest.TestCase):
             "ft.onto.base_ontology.Sentence",
             "teacher",
             1,
-            "Postive",
-            None,
-            None,
+            {"Postive": 0},
+            {},
+            {},
         ]
         ref4 = [
             55,
@@ -194,9 +195,9 @@ class DataStoreTest(unittest.TestCase):
             "ft.onto.base_ontology.Sentence",
             None,
             None,
-            "Negative",
-            "Class C",
-            "Class D",
+            {"Negative": 0},
+            {"Class C": 0},
+            {},
         ]
         ref5 = [
             10,
@@ -205,12 +206,21 @@ class DataStoreTest(unittest.TestCase):
             "forte.data.ontology.top.Annotation",
         ]
 
+        sorting_fn = lambda s: (
+            s[constants.BEGIN_INDEX], s[constants.END_INDEX],
+        )
         self.data_store._DataStore__elements = {
-            "ft.onto.base_ontology.Document": SortedList([ref1, ref2]),
-            "ft.onto.base_ontology.Sentence": SortedList([ref3, ref4]),
+            "ft.onto.base_ontology.Document": SortedList(
+                [ref1, ref2], key=sorting_fn
+            ),
+            "ft.onto.base_ontology.Sentence": SortedList(
+                [ref3, ref4], key=sorting_fn
+            ),
             # empty list corresponds to Entry, test only
             "forte.data.ontology.core.Entry": SortedList([]),
-            "forte.data.ontology.top.Annotation": SortedList([ref5]),
+            "forte.data.ontology.top.Annotation": SortedList(
+                [ref5], key=sorting_fn
+            ),
             "forte.data.ontology.top.Group": [
                 [
                     "ft.onto.base_ontology.Sentence",
@@ -320,9 +330,9 @@ class DataStoreTest(unittest.TestCase):
                 5,
                 1234,
                 "ft.onto.base_ontology.Document",
-                None,
-                "Postive",
-                None,
+                [],
+                {"Postive": 0},
+                {},
             ],
             [
                 6,
@@ -331,18 +341,18 @@ class DataStoreTest(unittest.TestCase):
                 "ft.onto.base_ontology.Sentence",
                 "teacher",
                 1,
-                "Postive",
-                None,
-                None,
+                {"Postive": 0},
+                {},
+                {},
             ],
             [
                 10,
                 25,
                 3456,
                 "ft.onto.base_ontology.Document",
-                "Doc class A",
-                "Negative",
-                "Class B",
+                ["Doc class A"],
+                {"Negative": 0},
+                {},
             ],
             [
                 55,
@@ -351,9 +361,9 @@ class DataStoreTest(unittest.TestCase):
                 "ft.onto.base_ontology.Sentence",
                 None,
                 None,
-                "Negative",
-                "Class C",
-                "Class D",
+                {"Negative": 0},
+                {"Class C": 0},
+                {},
             ],
         ]
 
@@ -367,18 +377,18 @@ class DataStoreTest(unittest.TestCase):
                 5,
                 1234,
                 "ft.onto.base_ontology.Document",
-                None,
-                "Postive",
-                None,
+                [],
+                {"Postive": 0},
+                {},
             ],
             [
                 0,
                 25,
                 3456,
                 "ft.onto.base_ontology.Document",
-                "Doc class A",
-                "Negative",
-                "Class B",
+                ["Doc class A"],
+                {"Negative": 0},
+                {},
             ],
             [
                 6,
@@ -387,9 +397,9 @@ class DataStoreTest(unittest.TestCase):
                 "ft.onto.base_ontology.Sentence",
                 "teacher",
                 1,
-                "Postive",
-                None,
-                None,
+                {"Postive": 0},
+                {},
+                {},
             ],
             [
                 55,
@@ -398,9 +408,9 @@ class DataStoreTest(unittest.TestCase):
                 "ft.onto.base_ontology.Sentence",
                 None,
                 None,
-                "Negative",
-                "Class C",
-                "Class D",
+                {"Negative": 0},
+                {"Class C": 0},
+                {},
             ],
         ]
         doc_tn = "ft.onto.base_ontology.Document"
@@ -419,27 +429,27 @@ class DataStoreTest(unittest.TestCase):
                 "ft.onto.base_ontology.Sentence",
                 "teacher",
                 1,
-                "Postive",
-                None,
-                None,
+                {"Postive": 0},
+                {},
+                {},
             ],
             [
                 0,
                 5,
                 1234,
                 "ft.onto.base_ontology.Document",
-                None,
-                "Postive",
-                None,
+                [],
+                {"Postive": 0},
+                {},
             ],
             [
                 0,
                 25,
                 3456,
                 "ft.onto.base_ontology.Document",
-                "Doc class A",
-                "Negative",
-                "Class B",
+                ["Doc class A"],
+                {"Negative": 0},
+                {},
             ],
             [
                 55,
@@ -448,9 +458,9 @@ class DataStoreTest(unittest.TestCase):
                 "ft.onto.base_ontology.Sentence",
                 None,
                 None,
-                "Negative",
-                "Class C",
-                "Class D",
+                {"Negative": 0},
+                {"Class C": 0},
+                {},
             ],
         ]
         ordered_elements2 = copy.deepcopy(ordered_elements1)
@@ -538,6 +548,22 @@ class DataStoreTest(unittest.TestCase):
             self.data_store.get_entry(tid=tid_em)[0],
             [10, 12, tid_em, "ft.onto.base_ontology.EntityMention", None],
         )
+
+        # test add duplicate Sentence entry
+        tid_sent_duplicate: int = self.data_store.add_annotation_raw(
+            "ft.onto.base_ontology.Sentence", 5, 8, allow_duplicate=False
+        )
+        self.assertEqual(len(self.data_store._DataStore__elements[
+            "ft.onto.base_ontology.Sentence"
+        ]), num_sent)
+        self.assertEqual(tid_sent, tid_sent_duplicate)
+        self.data_store.add_annotation_raw(
+            "ft.onto.base_ontology.Sentence", 5, 9,  allow_duplicate=False
+        )
+        self.assertEqual(len(self.data_store._DataStore__elements[
+            "ft.onto.base_ontology.Sentence"
+        ]), num_sent + 1)
+
         # check add annotation raw with tid
         tid = 77
         self.data_store.add_annotation_raw(
@@ -601,7 +627,7 @@ class DataStoreTest(unittest.TestCase):
         classifications = self.data_store.get_attribute(3456, "classifications")
 
         self.assertEqual(speaker, "teacher")
-        self.assertEqual(classifications, "Class B")
+        self.assertEqual(classifications, {})
 
         # Entry with such tid does not exist
         with self.assertRaisesRegex(KeyError, "Entry with tid 1111 not found."):
@@ -646,9 +672,9 @@ class DataStoreTest(unittest.TestCase):
                     "ft.onto.base_ontology.Sentence",
                     None,
                     None,
-                    "Negative",
-                    "Class C",
-                    "Class D",
+                    {"Negative": 0},
+                    {"Class C": 0},
+                    {},
                 ],
                 "ft.onto.base_ontology.Sentence",
             ),
@@ -783,9 +809,9 @@ class DataStoreTest(unittest.TestCase):
                 25,
                 3456,
                 "ft.onto.base_ontology.Document",
-                "Doc class A",
-                "Negative",
-                "Class B",
+                ["Doc class A"],
+                {"Negative": 0},
+                {},
             ],
         )
         # Last entry in list does not have a next entry.
@@ -802,9 +828,9 @@ class DataStoreTest(unittest.TestCase):
                 5,
                 1234,
                 "ft.onto.base_ontology.Document",
-                None,
-                "Postive",
-                None,
+                [],
+                {"Postive": 0},
+                {},
             ],
         )
         # First entry in list does not have a previous entry.

--- a/tests/forte/data/data_store_test.py
+++ b/tests/forte/data/data_store_test.py
@@ -558,7 +558,7 @@ class DataStoreTest(unittest.TestCase):
         ]), num_sent)
         self.assertEqual(tid_sent, tid_sent_duplicate)
         self.data_store.add_annotation_raw(
-            "ft.onto.base_ontology.Sentence", 5, 9,  allow_duplicate=False
+            "ft.onto.base_ontology.Sentence", 5, 9, allow_duplicate=False
         )
         self.assertEqual(len(self.data_store._DataStore__elements[
             "ft.onto.base_ontology.Sentence"


### PR DESCRIPTION
This PR fixes #774. 

### Description of changes
* Provide an option called `allow_duplicate` to specify whether to add identical entries into DataPack. If it's set to `False`, then  `add_annnotation_raw` should just return the existing entry if a duplicate is found.
* Fix incorrect attribute types in setup according to updates from #796.

### Test Conducted
`test_add_annotation_raw` is updated to test duplicate checking
