### PR TITLE
Bump minor version and pack version

### DIFF
--- a/forte/version.py
+++ b/forte/version.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 _MAJOR = "0"
-_MINOR = "2"
-_REVISION = "0"
+_MINOR = "3"
+_REVISION = "0.dev1"
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
 VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)
 FORTE_IR_VERSION = "0.0.1"
-PACK_VERSION = "0.0.1"
+PACK_VERSION = "0.0.2"
 DEFAULT_PACK_VERSION = "0.0.0"
-PACK_ID_COMPATIBLE_VERSION = "0.0.1"
+PACK_ID_COMPATIBLE_VERSION = "0.0.2"


### PR DESCRIPTION
### Description of changes
`forte` version is upgraded to "0.3.0.dev1".
 `PACK_VERSION` and `PACK_ID_COMPATIBLE_VERSION ` are set to `0.0.2`.
