### PR TITLE
Add Entry Raw Method

### DIFF
--- a/forte/data/base_store.py
+++ b/forte/data/base_store.py
@@ -135,7 +135,7 @@ class BaseStore:
     ) -> int:
 
         r"""
-        This function proves a general implementation to add all
+        This function provides a general implementation to add all
         types of entries to the data store. It can add namely
         Annotation, AudioAnnotation, ImageAnnotation,
         Link, Group and Generics. Returns the ``tid`` for the

--- a/forte/data/base_store.py
+++ b/forte/data/base_store.py
@@ -14,8 +14,8 @@
 
 from abc import abstractmethod
 from typing import List, Iterator, Tuple, Any, Optional, Dict, Type
-from forte.data.ontology.core import Entry
 import json
+from forte.data.ontology.core import Entry
 
 __all__ = ["BaseStore"]
 

--- a/forte/data/base_store.py
+++ b/forte/data/base_store.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from typing import List, Iterator, Tuple, Any, Optional, Dict
+from typing import List, Iterator, Tuple, Any, Optional, Dict, Type
+from forte.data.ontology.core import Entry
 import json
 
 __all__ = ["BaseStore"]

--- a/forte/data/data_pack.py
+++ b/forte/data/data_pack.py
@@ -1973,53 +1973,59 @@ class EntryConverter:
 
         # Create a new registry in DataStore based on entry's type
         if isinstance(entry, Annotation):
-            data_store_ref.add_annotation_raw(
+            data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                begin=entry.begin,
-                end=entry.end,
+                attribute_data=[entry.begin, entry.end],
+                base_class=Annotation,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
             )
         elif isinstance(entry, Link):
-            data_store_ref.add_link_raw(
+            data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                parent_tid=entry.parent,
-                child_tid=entry.child,
+                attribute_data=[entry.parent, entry.child],
+                base_class=Link,
                 tid=entry.tid,
             )
         elif isinstance(entry, Group):
-            data_store_ref.add_group_raw(
+            data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                member_type=get_full_module_name(entry.MemberType),
+                attribute_data=[get_full_module_name(entry.MemberType), []],
+                base_class=Group,
                 tid=entry.tid,
             )
         elif isinstance(entry, Generics):
-            data_store_ref.add_generics_raw(
+            data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
+                attribute_data=[None, None],
+                base_class=Generics,
                 tid=entry.tid,
             )
         elif isinstance(entry, AudioAnnotation):
-            data_store_ref.add_audio_annotation_raw(
+            data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                begin=entry.begin,
-                end=entry.end,
+                attribute_data=[entry.begin, entry.end],
+                base_class=AudioAnnotation,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
             )
         elif isinstance(entry, ImageAnnotation):
-            data_store_ref.add_image_annotation_raw(
+            data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                image_payload_idx=entry.image_payload_idx,
+                attribute_data=[entry.image_payload_idx, None],
+                base_class=ImageAnnotation,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
             )
         elif isinstance(entry, Grids):
-            data_store_ref.add_grid_raw(
+            data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                image_payload_idx=entry.image_payload_idx,
+                attribute_data=[entry.image_payload_idx, None],
+                base_class=Grids,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
             )
+
         else:
             raise ValueError(
                 f"Invalid entry type {type(entry)}. A valid entry "

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -993,7 +993,7 @@ class DataStore(BaseStore):
         r"""
         This function proves a general implementation to add all
         types of entries to the data store. It can add namely
-        Annotation, AudioAnnotation, ImageAnnotation, Grids,
+        Annotation, AudioAnnotation, ImageAnnotation,
         Link, Group and Generics. Returns the ``tid`` for the
         inserted entry.
 

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -953,6 +953,81 @@ class DataStore(BaseStore):
         else:
             raise KeyError(f"Entry with tid {tid} not found.")
 
+    def _create_new_entry(
+        self, type_name: str, attribute_data: List, tid: Optional[int] = None
+    ) -> List:
+        r"""This function generates a new entry with default fields.
+        The new entry is in the format used to be stored in Data Stores.
+
+        Args:
+            type_name: The fully qualified type name of the new entry.
+            attribute_data: It is a list that stores attributes relevant to
+                the entry being added. In order to keep the number of attributes
+                same for all entries, the list is populated with trailing None's.
+            tid: ``tid`` of the generics entry.
+
+        Returns:
+            The list that represents the newly created entry.
+        """
+
+        tid: int = self._new_tid() if tid is None else tid
+        entry: List[Any] = []
+
+        for attribute in attribute_data:
+            entry.append(attribute)
+
+        entry += [tid, type_name]
+        entry += self._default_attributes_for_type(type_name)
+
+        return entry
+
+    def add_entry_raw(
+        self,
+        type_name: str,
+        attribute_data: List,
+        base_class: Type[Entry],
+        tid: Optional[int] = None,
+        allow_duplicate: bool = True,
+    ) -> int:
+
+        r"""
+        This function proves a general implementation to add all
+        types of entries to the data store. It can add namely
+        Annotation, AudioAnnotation, ImageAnnotation, Link, Group
+        and Generics.Returns the ``tid`` for the inserted entry.
+
+        Args:
+            type_name: The fully qualified type name of the new Annotation.
+            attribute_data: It is a list that stores attributes relevant to
+                the entry being added. In order to keep the number of attributes
+                same for all entries, the list is populated with trailing None's.
+            base_class: The type of entry to add to the Data Store.
+            tid: ``tid`` of the Entry that is being added.
+                It's optional, and it will be
+                auto-assigned if not given.
+            allow_duplicate: Whether we allow duplicate in the DataStore. When
+                it's set to False, the function will return the ``tid`` of
+                existing entry if a duplicate is found. Default value is True.
+
+        Returns:
+            ``tid`` of the entry.
+        """
+
+        new_entry = self._create_new_entry(type_name, attribute_data, tid)
+
+        if any(
+            self._is_subclass(type_name, e) for e in [Link, Group, Generics]
+        ):
+            allow_duplicate = True
+
+        if not allow_duplicate:
+            tid_search_result = self._get_existing_ann_entry_tid(new_entry)
+            # if found existing entry
+            if tid_search_result != -1:
+                return tid_search_result
+
+        return self._add_entry_raw(base_class, type_name, new_entry)
+
     def add_annotation_raw(
         self,
         type_name: str,

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -986,8 +986,7 @@ class DataStore(BaseStore):
         tid: int = self._new_tid() if tid is None else tid
         entry: List[Any] = []
 
-        for attribute in attribute_data:
-            entry.append(attribute)
+        entry.extend(attribute_data)
 
         entry += [tid, type_name]
         entry += self._default_attributes_for_type(type_name)
@@ -1004,7 +1003,7 @@ class DataStore(BaseStore):
     ) -> int:
 
         r"""
-        This function proves a general implementation to add all
+        This function provides a general implementation to add all
         types of entries to the data store. It can add namely
         Annotation, AudioAnnotation, ImageAnnotation,
         Link, Group and Generics. Returns the ``tid`` for the

--- a/forte/data/data_store.py
+++ b/forte/data/data_store.py
@@ -993,15 +993,19 @@ class DataStore(BaseStore):
         r"""
         This function proves a general implementation to add all
         types of entries to the data store. It can add namely
-        Annotation, AudioAnnotation, ImageAnnotation, Link, Group
-        and Generics.Returns the ``tid`` for the inserted entry.
+        Annotation, AudioAnnotation, ImageAnnotation, Grids,
+        Link, Group and Generics. Returns the ``tid`` for the
+        inserted entry.
 
         Args:
-            type_name: The fully qualified type name of the new Annotation.
+            type_name: The fully qualified type name of the new Entry.
             attribute_data: It is a list that stores attributes relevant to
                 the entry being added. In order to keep the number of attributes
                 same for all entries, the list is populated with trailing None's.
-            base_class: The type of entry to add to the Data Store.
+            base_class: The type of entry to add to the Data Store. This is
+                a reference to the class of the entry that needs to be added
+                to the DataStore. The reference can be to any of the classes
+                supported by the function.
             tid: ``tid`` of the Entry that is being added.
                 It's optional, and it will be
                 auto-assigned if not given.
@@ -1015,9 +1019,7 @@ class DataStore(BaseStore):
 
         new_entry = self._create_new_entry(type_name, attribute_data, tid)
 
-        if any(
-            self._is_subclass(type_name, e) for e in [Link, Group, Generics]
-        ):
+        if not self._is_annotation(type_name):
             allow_duplicate = True
 
         if not allow_duplicate:

--- a/forte/data/entry_converter.py
+++ b/forte/data/entry_converter.py
@@ -127,7 +127,7 @@ class EntryConverter:
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
                 attribute_data=[
-                    [entry.parent[0], entry.parent[1]], 
+                    [entry.parent[0], entry.parent[1]],
                     [entry.child[0], entry.child[1]],
                 ],
                 base_class=MultiPackLink,

--- a/forte/data/entry_converter.py
+++ b/forte/data/entry_converter.py
@@ -72,7 +72,7 @@ class EntryConverter:
         if data_store_ref._is_subclass(entry.entry_type(), Annotation):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[entry.begin, entry.end],  # type: ignore
+                attribute_data=[entry.begin, entry.end],
                 base_class=Annotation,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
@@ -80,14 +80,14 @@ class EntryConverter:
         elif data_store_ref._is_subclass(entry.entry_type(), Link):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[entry.parent, entry.child],  # type: ignore
+                attribute_data=[entry.parent, entry.child],
                 base_class=Link,
                 tid=entry.tid,
             )
         elif data_store_ref._is_subclass(entry.entry_type(), Group):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[get_full_module_name(entry.MemberType), []],  # type: ignore
+                attribute_data=[get_full_module_name(entry.MemberType), []],
                 base_class=Group,
                 tid=entry.tid,
             )
@@ -101,7 +101,7 @@ class EntryConverter:
         elif data_store_ref._is_subclass(entry.entry_type(), AudioAnnotation):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[entry.begin, entry.end],  # type: ignore
+                attribute_data=[entry.begin, entry.end],
                 base_class=AudioAnnotation,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
@@ -109,7 +109,7 @@ class EntryConverter:
         elif data_store_ref._is_subclass(entry.entry_type(), ImageAnnotation):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[entry.image_payload_idx, None],  # type: ignore
+                attribute_data=[entry.image_payload_idx, None],
                 base_class=ImageAnnotation,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
@@ -118,7 +118,7 @@ class EntryConverter:
             # Will be deprecated in future
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[entry.image_payload_idx, None],  # type: ignore
+                attribute_data=[entry.image_payload_idx, None],
                 base_class=Grids,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
@@ -127,8 +127,8 @@ class EntryConverter:
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
                 attribute_data=[
-                    [entry.parent[0], entry.parent[1]],  # type: ignore
-                    [entry.child[0], entry.child[1]],  # type: ignore
+                    [entry.parent[0], entry.parent[1]], 
+                    [entry.child[0], entry.child[1]],
                 ],
                 base_class=MultiPackLink,
                 tid=entry.tid,
@@ -136,7 +136,7 @@ class EntryConverter:
         elif data_store_ref._is_subclass(entry.entry_type(), MultiPackGroup):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[get_full_module_name(entry.MemberType), []],  # type: ignore
+                attribute_data=[get_full_module_name(entry.MemberType), []],
                 base_class=MultiPackGroup,
                 tid=entry.tid,
             )

--- a/forte/data/entry_converter.py
+++ b/forte/data/entry_converter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from forte.data.base_pack import PackType
 from forte.data.ontology.core import Entry, FList, FDict
 from forte.data.ontology.core import EntryType
@@ -49,7 +49,7 @@ class EntryConverter:
         self._entry_dict: Dict[int, Entry] = {}
 
     def save_entry_object(
-        self, entry: Entry, pack: PackType, allow_duplicate: bool = True
+        self, entry: Any, pack: PackType, allow_duplicate: bool = True
     ):
         # pylint: disable=protected-access
         """
@@ -94,7 +94,7 @@ class EntryConverter:
         elif data_store_ref._is_subclass(entry.entry_type(), Generics):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[None, None],  # type: ignore
+                attribute_data=[None, None],
                 base_class=Generics,
                 tid=entry.tid,
             )
@@ -143,7 +143,7 @@ class EntryConverter:
         elif data_store_ref._is_subclass(entry.entry_type(), MultiPackGeneric):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[None, None],  # type: ignore
+                attribute_data=[None, None],
                 base_class=MultiPackGeneric,
                 tid=entry.tid,
             )

--- a/forte/data/entry_converter.py
+++ b/forte/data/entry_converter.py
@@ -72,7 +72,7 @@ class EntryConverter:
         if data_store_ref._is_subclass(entry.entry_type(), Annotation):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[entry.begin, entry.end],
+                attribute_data=[entry.begin, entry.end],  # type: ignore
                 base_class=Annotation,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
@@ -80,28 +80,28 @@ class EntryConverter:
         elif data_store_ref._is_subclass(entry.entry_type(), Link):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[entry.parent, entry.child],
+                attribute_data=[entry.parent, entry.child],  # type: ignore
                 base_class=Link,
                 tid=entry.tid,
             )
         elif data_store_ref._is_subclass(entry.entry_type(), Group):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[get_full_module_name(entry.MemberType), []],
+                attribute_data=[get_full_module_name(entry.MemberType), []],  # type: ignore
                 base_class=Group,
                 tid=entry.tid,
             )
         elif data_store_ref._is_subclass(entry.entry_type(), Generics):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[None, None],
+                attribute_data=[None, None],  # type: ignore
                 base_class=Generics,
                 tid=entry.tid,
             )
         elif data_store_ref._is_subclass(entry.entry_type(), AudioAnnotation):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[entry.begin, entry.end],
+                attribute_data=[entry.begin, entry.end],  # type: ignore
                 base_class=AudioAnnotation,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
@@ -109,7 +109,7 @@ class EntryConverter:
         elif data_store_ref._is_subclass(entry.entry_type(), ImageAnnotation):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[entry.image_payload_idx, None],
+                attribute_data=[entry.image_payload_idx, None],  # type: ignore
                 base_class=ImageAnnotation,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
@@ -118,7 +118,7 @@ class EntryConverter:
             # Will be deprecated in future
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[entry.image_payload_idx, None],
+                attribute_data=[entry.image_payload_idx, None],  # type: ignore
                 base_class=Grids,
                 tid=entry.tid,
                 allow_duplicate=allow_duplicate,
@@ -127,8 +127,8 @@ class EntryConverter:
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
                 attribute_data=[
-                    [entry.parent[0], entry.parent[1]],
-                    [entry.child[0], entry.child[1]],
+                    [entry.parent[0], entry.parent[1]],  # type: ignore
+                    [entry.child[0], entry.child[1]],  # type: ignore
                 ],
                 base_class=MultiPackLink,
                 tid=entry.tid,
@@ -136,14 +136,14 @@ class EntryConverter:
         elif data_store_ref._is_subclass(entry.entry_type(), MultiPackGroup):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[get_full_module_name(entry.MemberType), []],
+                attribute_data=[get_full_module_name(entry.MemberType), []],  # type: ignore
                 base_class=MultiPackGroup,
                 tid=entry.tid,
             )
         elif data_store_ref._is_subclass(entry.entry_type(), MultiPackGeneric):
             data_store_ref.add_entry_raw(
                 type_name=entry.entry_type(),
-                attribute_data=[None, None],
+                attribute_data=[None, None],  # type: ignore
                 base_class=MultiPackGeneric,
                 tid=entry.tid,
             )

--- a/forte/data/entry_converter.py
+++ b/forte/data/entry_converter.py
@@ -68,62 +68,6 @@ class EntryConverter:
             # The entry is not found in DataStore
             pass
 
-        """
-        if isinstance(entry, Annotation):
-            data_store_ref.add_entry_raw(
-                type_name=entry.entry_type(),
-                attribute_data=[entry.begin, entry.end],
-                base_class=Annotation,
-                tid=entry.tid,
-                allow_duplicate=allow_duplicate,
-            )
-        elif isinstance(entry, Link):
-            data_store_ref.add_entry_raw(
-                type_name=entry.entry_type(),
-                attribute_data=[entry.parent, entry.child],
-                base_class=Link,
-                tid=entry.tid,
-            )
-        elif isinstance(entry, Group):
-            data_store_ref.add_entry_raw(
-                type_name=entry.entry_type(),
-                attribute_data=[get_full_module_name(entry.MemberType), []],
-                base_class=Group,
-                tid=entry.tid,
-            )
-        elif isinstance(entry, Generics):
-            data_store_ref.add_entry_raw(
-                type_name=entry.entry_type(),
-                attribute_data=[None, None],
-                base_class=Generics,
-                tid=entry.tid,
-            )
-        elif isinstance(entry, AudioAnnotation):
-            data_store_ref.add_entry_raw(
-                type_name=entry.entry_type(),
-                attribute_data=[entry.begin, entry.end],
-                base_class=AudioAnnotation,
-                tid=entry.tid,
-                allow_duplicate=allow_duplicate,
-            )
-        elif isinstance(entry, ImageAnnotation):
-            data_store_ref.add_entry_raw(
-                type_name=entry.entry_type(),
-                attribute_data=[entry.image_payload_idx, None],
-                base_class=ImageAnnotation,
-                tid=entry.tid,
-                allow_duplicate=allow_duplicate,
-            )
-        elif isinstance(entry, Grids):
-            data_store_ref.add_entry_raw(
-                type_name=entry.entry_type(),
-                attribute_data=[entry.image_payload_idx, None],
-                base_class=Grids,
-                tid=entry.tid,
-                allow_duplicate=allow_duplicate,
-            )
-        """
-
         # Create a new registry in DataStore based on entry's type
         if data_store_ref._is_subclass(entry.entry_type(), Annotation):
             data_store_ref.add_entry_raw(

--- a/tests/forte/data/data_store_test.py
+++ b/tests/forte/data/data_store_test.py
@@ -22,7 +22,13 @@ from sortedcontainers import SortedList
 from typing import Optional, Dict
 from dataclasses import dataclass
 from forte.data.data_store import DataStore
-from forte.data.ontology.top import Annotation, Generics
+from forte.data.ontology.top import (
+    Annotation,
+    Generics,
+    AudioAnnotation,
+    Group,
+    Link,
+)
 from forte.data.data_pack import DataPack
 from forte.common import constants
 
@@ -325,9 +331,11 @@ class DataStoreTest(unittest.TestCase):
         group_type = "forte.data.ontology.top.Group"
         sent_list = list(self.data_store._DataStore__elements[sent_type])
         doc_list = list(self.data_store._DataStore__elements[doc_type])
-        ann_list = list(self.data_store.co_iterator_annotation_like(
-            list(self.data_store._get_all_subclass(ann_type, True))
-        ))
+        ann_list = list(
+            self.data_store.co_iterator_annotation_like(
+                list(self.data_store._get_all_subclass(ann_type, True))
+            )
+        )
 
         group_list = list(self.data_store._DataStore__elements[group_type])
         sent_entries = list(self.data_store.all_entries(sent_type))
@@ -356,8 +364,10 @@ class DataStoreTest(unittest.TestCase):
         # add a sentence back and count
         add_count = 5
         for i in range(add_count):
-            self.data_store.add_annotation_raw(
-                "ft.onto.base_ontology.Sentence", i, i + 1
+            self.data_store.add_entry_raw(
+                type_name="ft.onto.base_ontology.Sentence",
+                attribute_data=[i, i + 1],
+                base_class=Annotation,
             )
         self.assertEqual(
             self.data_store.num_entries(sent_type),
@@ -547,12 +557,16 @@ class DataStoreTest(unittest.TestCase):
 
     def test_add_annotation_raw(self):
         # test add Document entry
-        tid_doc: int = self.data_store.add_annotation_raw(
-            "ft.onto.base_ontology.Document", 1, 5
+        tid_doc: int = self.data_store.add_entry_raw(
+            type_name="ft.onto.base_ontology.Document",
+            attribute_data=[1, 5],
+            base_class=Annotation,
         )
         # test add Sentence entry
-        tid_sent: int = self.data_store.add_annotation_raw(
-            "ft.onto.base_ontology.Sentence", 5, 8
+        tid_sent: int = self.data_store.add_entry_raw(
+            type_name="ft.onto.base_ontology.Sentence",
+            attribute_data=[5, 8],
+            base_class=Annotation,
         )
         num_doc = self.data_store.get_length("ft.onto.base_ontology.Document")
 
@@ -581,8 +595,10 @@ class DataStoreTest(unittest.TestCase):
         )
 
         # test add new annotation type
-        tid_em: int = self.data_store.add_annotation_raw(
-            "ft.onto.base_ontology.EntityMention", 10, 12
+        tid_em: int = self.data_store.add_entry_raw(
+            type_name="ft.onto.base_ontology.EntityMention",
+            attribute_data=[10, 12],
+            base_class=Annotation,
         )
         num_phrase = self.data_store.get_length(
             "ft.onto.base_ontology.EntityMention"
@@ -597,8 +613,11 @@ class DataStoreTest(unittest.TestCase):
         )
 
         # test add duplicate Sentence entry
-        tid_sent_duplicate: int = self.data_store.add_annotation_raw(
-            "ft.onto.base_ontology.Sentence", 5, 8, allow_duplicate=False
+        tid_sent_duplicate: int = self.data_store.add_entry_raw(
+            type_name="ft.onto.base_ontology.Sentence",
+            attribute_data=[5, 8],
+            base_class=Annotation,
+            allow_duplicate=False,
         )
         self.assertEqual(
             len(
@@ -609,8 +628,11 @@ class DataStoreTest(unittest.TestCase):
             num_sent,
         )
         self.assertEqual(tid_sent, tid_sent_duplicate)
-        self.data_store.add_annotation_raw(
-            "ft.onto.base_ontology.Sentence", 5, 9, allow_duplicate=False
+        self.data_store.add_entry_raw(
+            type_name="ft.onto.base_ontology.Sentence",
+            attribute_data=[5, 9],
+            base_class=Annotation,
+            allow_duplicate=False,
         )
         self.assertEqual(
             len(
@@ -623,8 +645,11 @@ class DataStoreTest(unittest.TestCase):
 
         # check add annotation raw with tid
         tid = 77
-        self.data_store.add_annotation_raw(
-            "ft.onto.base_ontology.Sentence", 0, 1, tid
+        self.data_store.add_entry_raw(
+            type_name="ft.onto.base_ontology.Sentence",
+            attribute_data=[0, 1],
+            base_class=Annotation,
+            tid=tid,
         )
         self.assertEqual(
             self.data_store.get_entry(tid=77)[0],
@@ -643,15 +668,21 @@ class DataStoreTest(unittest.TestCase):
 
     def test_add_audio_annotation_raw(self):
         # test add Document entry
-        tid_recording: int = self.data_store.add_audio_annotation_raw(
-            "ft.onto.base_ontology.Recording", 1, 5
+        tid_recording: int = self.data_store.add_entry_raw(
+            type_name="ft.onto.base_ontology.Recording",
+            attribute_data=[1, 5],
+            base_class=AudioAnnotation,
         )
         # test add Sentence entry
-        tid_audio_utterance: int = self.data_store.add_audio_annotation_raw(
-            "ft.onto.base_ontology.AudioUtterance", 5, 8
+        tid_audio_utterance: int = self.data_store.add_entry_raw(
+            type_name="ft.onto.base_ontology.AudioUtterance",
+            attribute_data=[5, 8],
+            base_class=AudioAnnotation,
         )
-        tid_utterance: int = self.data_store.add_annotation_raw(
-            "ft.onto.base_ontology.Utterance", 5, 8
+        tid_utterance: int = self.data_store.add_entry_raw(
+            type_name="ft.onto.base_ontology.Utterance",
+            attribute_data=[5, 8],
+            base_class=Annotation,
         )
         # check number of Recording
         self.assertEqual(
@@ -681,8 +712,11 @@ class DataStoreTest(unittest.TestCase):
             1,
         )
         tid = 77
-        self.data_store.add_audio_annotation_raw(
-            "ft.onto.base_ontology.Recording", 0, 1, tid
+        self.data_store.add_entry_raw(
+            type_name="ft.onto.base_ontology.Recording",
+            attribute_data=[0, 1],
+            base_class=AudioAnnotation,
+            tid=tid,
         )
         self.assertEqual(
             self.data_store.get_entry(tid=77)[0],
@@ -691,8 +725,10 @@ class DataStoreTest(unittest.TestCase):
 
     def test_add_generics_raw(self):
         # test add Document entry
-        tid_generics: int = self.data_store.add_generics_raw(
-            "forte.data.ontology.top.Generics"
+        tid_generics: int = self.data_store.add_entry_raw(
+            type_name="forte.data.ontology.top.Generics",
+            attribute_data=[None, None],
+            base_class=Generics,
         )
         # check number of Generics
         self.assertEqual(
@@ -704,8 +740,11 @@ class DataStoreTest(unittest.TestCase):
             1,
         )
         tid = 77
-        self.data_store.add_generics_raw(
-            "forte.data.ontology.top.Generics", tid
+        self.data_store.add_entry_raw(
+            type_name="forte.data.ontology.top.Generics",
+            attribute_data=[None, None],
+            base_class=Generics,
+            tid=tid,
         )
         self.assertEqual(
             self.data_store.get_entry(tid=77)[0],
@@ -713,8 +752,10 @@ class DataStoreTest(unittest.TestCase):
         )
 
     def test_add_link_raw(self):
-        self.data_store.add_link_raw(
-            "forte.data.ontology.top.Link", 9999, 1234567
+        self.data_store.add_entry_raw(
+            type_name="forte.data.ontology.top.Link",
+            attribute_data=[9999, 1234567],
+            base_class=Link,
         )
         # check number of Link
         self.assertEqual(
@@ -728,15 +769,22 @@ class DataStoreTest(unittest.TestCase):
 
         # check add link with tid
         tid = 77
-        self.data_store.add_link_raw("forte.data.ontology.top.Link", 0, 1, tid)
+        self.data_store.add_entry_raw(
+            type_name="forte.data.ontology.top.Link",
+            attribute_data=[0, 1],
+            base_class=Link,
+            tid=tid,
+        )
         self.assertEqual(
             self.data_store.get_entry(tid=77)[0],
             [0, 1, tid, "forte.data.ontology.top.Link"],
         )
 
     def test_add_group_raw(self):
-        self.data_store.add_group_raw(
-            "forte.data.ontology.top.Group", 9999, 1234567
+        self.data_store.add_entry_raw(
+            type_name="forte.data.ontology.top.Group",
+            attribute_data=["dummy_group", []],
+            base_class=Group,
         )
         # check number of Group
         self.assertEqual(
@@ -750,8 +798,11 @@ class DataStoreTest(unittest.TestCase):
 
         # check add group with tid
         tid = 77
-        self.data_store.add_group_raw(
-            "forte.data.ontology.top.Group", "test_group", tid
+        self.data_store.add_entry_raw(
+            type_name="forte.data.ontology.top.Group",
+            attribute_data=["test_group", []],
+            base_class=Group,
+            tid=tid,
         )
         self.assertEqual(
             self.data_store.get_entry(tid=77)[0],
@@ -1139,7 +1190,9 @@ class DataStoreTest(unittest.TestCase):
                 self.data_store.get_entry(tid=tid)[1]
             ):
                 entry_val = getattr(entry, attribute)
-                ref_val = self.data_store.get_attribute(tid=tid, attr_name=attribute)
+                ref_val = self.data_store.get_attribute(
+                    tid=tid, attr_name=attribute
+                )
                 if isinstance(ref_val, (list, dict)):
                     continue
                 self.assertEqual(entry_val, ref_val)


### PR DESCRIPTION
This PR fixes #837 . 

### Description of changes
In this PR, we created the `add_entry_raw` method which acts as a single interface for adding all different types pf entries. ie, `Annotation`, `AudioAnnotation`, `Group`, `Link`, `ImageAnnotation` and `Generics`. This is done by introducing the argument `attribute_data` which acts as a common medium for all types of entries to be created in the same way. The type of values being passed in `attribute_data` is dependent on the type of entries. (Currently, the length of the `attribute_data` list is **2** as those are the number of attributes required currently.

### Possible influences of this PR.
Through this PR, the need for having separate `add_***_raw` method is gone and we can use just one method to add different types of entries.

### Test Conducted
The `data_store_test.py` file was modified to use the new `add_entry_raw` method to test the working if the unified interface.
