### PR TITLE
Datapack audio

### DIFF
--- a/forte/data/data_pack.py
+++ b/forte/data/data_pack.py
@@ -167,7 +167,6 @@ class DataPack(BasePack[Entry, Link, Group]):
 
     def __init__(self, pack_name: Optional[str] = None):
         super().__init__(pack_name)
-        self._audio: Optional[np.ndarray] = None
 
         self._data_store: DataStore = DataStore()
         self._entry_converter: EntryConverter = EntryConverter()
@@ -241,6 +240,11 @@ class DataPack(BasePack[Entry, Link, Group]):
             return str(self.get_payload_data_at(Modality.Text, 0))
         else:
             return ""
+
+    @property
+    def audio(self) -> Optional[np.ndarray]:
+        r"""Return the audio of the data pack"""
+        return self.get_payload_data_at(Modality.Audio, 0)
 
     @property
     def all_annotations(self) -> Iterator[Annotation]:

--- a/tests/forte/data/audio_annotation_test.py
+++ b/tests/forte/data/audio_annotation_test.py
@@ -50,7 +50,7 @@ class RecordingProcessor(PackProcessor):
         Recording(
             pack=input_pack,
             begin=0,
-            end=len(input_pack.get_payload_data_at(Modality.Audio, 0)),
+            end=len(input_pack.audio),
         )
 
 
@@ -208,7 +208,7 @@ class AudioAnnotationTest(unittest.TestCase):
             self.assertTrue(
                 array_equal(
                     recordings[0].audio,
-                    pack.get_payload_data_at(Modality.Audio, 0),
+                    pack.audio,
                 )
             )
             # Check serialization/deserialization of AudioAnnotation
@@ -230,9 +230,7 @@ class AudioAnnotationTest(unittest.TestCase):
                     self.assertTrue(
                         array_equal(
                             audio_utter.audio,
-                            pack.get_payload_data_at(Modality.Audio, 0)[
-                                configs["begin"] : configs["end"]
-                            ],
+                            pack.audio[configs["begin"] : configs["end"]],
                         )
                     )
 


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/856

### Description of changes
* add `DataPack.audio` back but it's retrieve audio data from audio payloads instead of `DataPack._audio`

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
