### PR TITLE
Remove a warning from code gen that occurs frequently

### DIFF
--- a/forte/data/ontology/code_generation_objects.py
+++ b/forte/data/ontology/code_generation_objects.py
@@ -14,6 +14,7 @@
 import itertools as it
 import logging
 import os
+import warnings
 from abc import ABC
 from pathlib import Path
 from typing import Optional, Any, List, Dict, Set, Tuple
@@ -21,6 +22,7 @@ from numpy import ndarray
 
 from forte.data.ontology.code_generation_exceptions import (
     CodeGenerationException,
+    OntologyGenerationWarning,
 )
 from forte.data.ontology.ontology_code_const import (
     SUPPORTED_PRIMITIVES,
@@ -173,10 +175,10 @@ class ImportManager:
             if class_name not in self.__short_name_pool:
                 self.__short_name_pool.add(class_name)
             else:
-                logging.warning(
-                    "Re-declared a new class named [%s]"
+                warnings.warn(
+                    f"Re-declared a new class named [{class_name}]"
                     ", which is probably used in import.",
-                    class_name,
+                    OntologyGenerationWarning,
                 )
             self.__defining_names[full_name] = class_name
 

--- a/forte/data/ontology/ontology_code_generator.py
+++ b/forte/data/ontology/ontology_code_generator.py
@@ -794,12 +794,12 @@ class OntologyCodeGenerator:
 
             # Get various parts of the entry name.
             en = EntryName(raw_entry_name)
-            entry_item, properties = self.parse_entry(en, definition)
-
-            # Add it as a defining object.
+            # First add the entry, and then parse the attribute. In this
+            #  order, we can avoid some incorrect warning.
             self.import_managers.get(en.module_name).add_defining_objects(
                 raw_entry_name
             )
+            entry_item, properties = self.parse_entry(en, definition)
 
             # Get or set module writer only if the ontology to be generated
             # is not already installed.

--- a/tests/forte/data/ontology/ontology_code_generator_test.py
+++ b/tests/forte/data/ontology/ontology_code_generator_test.py
@@ -23,6 +23,7 @@ import warnings
 from string import Template
 
 import jsonschema
+import pytest
 from ddt import ddt, data
 from testfixtures import LogCapture, log_capture
 
@@ -170,38 +171,50 @@ class GenerateOntologyTest(unittest.TestCase):
             self.assertEqual(gen_files, exp_files)
 
     @data(
-        (True, "test_duplicate_entry.json", DuplicateEntriesWarning),
-        (True, "test_duplicate_attr_name.json", DuplicatedAttributesWarning),
-        (True, "test_ndarray_dtype_only.json", UserWarning),
-        (True, "test_ndarray_shape_only.json", UserWarning),
-        (False, "example_ontology.json", OntologySourceNotFoundException),
-        (False, "test_invalid_parent.json", ParentEntryNotSupportedException),
-        (False, "test_invalid_attribute.json", TypeNotDeclaredException),
-        (False, "test_nested_item_type.json", UnsupportedTypeException),
-        (False, "test_no_item_type.json", TypeNotDeclaredException),
-        (False, "test_unknown_item_type.json", TypeNotDeclaredException),
-        (False, "test_invalid_entry_name.json", InvalidIdentifierException),
-        (False, "test_invalid_attr_name.json", InvalidIdentifierException),
-        (False, "test_non_string_keys.json", CodeGenerationException),
+        (True, "test_duplicate_entry.json", DuplicateEntriesWarning, True),
+        (True, "test_duplicate_attr_name.json", DuplicatedAttributesWarning, True),
+        (True, "test_ndarray_dtype_only.json", UserWarning, True),
+        (True, "test_ndarray_shape_only.json", UserWarning, True),
+        (True, "test_self_reference.json", UserWarning, False),
+        (False, "example_ontology.json", OntologySourceNotFoundException, True),
+        (False, "test_invalid_parent.json", ParentEntryNotSupportedException, True),
+        (False, "test_invalid_attribute.json", TypeNotDeclaredException, True),
+        (False, "test_nested_item_type.json", UnsupportedTypeException, True),
+        (False, "test_no_item_type.json", TypeNotDeclaredException, True),
+        (False, "test_unknown_item_type.json", TypeNotDeclaredException, True),
+        (False, "test_invalid_entry_name.json", InvalidIdentifierException, True),
+        (False, "test_invalid_attr_name.json", InvalidIdentifierException, True),
+        (False, "test_non_string_keys.json", CodeGenerationException, True),
     )
     def test_warnings_errors(self, value):
-        expected_warning, file, msg_type = value
+        is_warning, file, msg_type, expect_happen = value
         temp_dir = tempfile.mkdtemp()
         json_file_name = os.path.join(self.spec_dir, file)
         temp_filename = _get_temp_filename(json_file_name, temp_dir)
-        if expected_warning:
+        if is_warning:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 self.generator.generate(
                     temp_filename, temp_dir, is_dry_run=True
                 )
-                self.assertEqual(len(w), 1)
-                assert w[0].category, msg_type
+                if expect_happen:
+                    self.assertEqual(len(w), 1)
+                    assert w[0].category, msg_type
+                else:
+                    self.assertEqual(len(w), 0)
         else:
-            with self.assertRaises(msg_type):
-                self.generator.generate(
-                    temp_filename, temp_dir, is_dry_run=True
-                )
+            if expect_happen:
+                with self.assertRaises(msg_type):
+                    self.generator.generate(
+                        temp_filename, temp_dir, is_dry_run=True
+                    )
+            else:
+                try:
+                    self.generator.generate(
+                        temp_filename, temp_dir, is_dry_run=True
+                    )
+                except msg_type:
+                    pytest.fail("Shouldn't raise this exception.")
 
     @log_capture()
     def test_directory_already_present(self):

--- a/tests/forte/data/ontology/test_specs/test_self_reference.json
+++ b/tests/forte/data/ontology/test_specs/test_self_reference.json
@@ -1,0 +1,20 @@
+{
+    "name": "test_ontology",
+    "definitions": [
+        {
+            "entry_name": "ft.onto.test_ontology.Token",
+            "parent_entry": "forte.data.ontology.top.Annotation",
+            "description": "Base parent token entry",
+            "attributes": [
+                {
+                    "name": "related_token",
+                    "type": "ft.onto.test_ontology.Token"
+                },
+                {
+                    "name": "pos",
+                    "type": "int"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/862. 

### Description of changes
Reorder the generation steps can solve the problem, if we make sure we parse the entry name before the arguments, the warning won't happen for us.

### Possible influences of this PR.
This may change the code generation steps slightly, but if all the code gen tests pass, then it shouldn't introduce any influences.

### Test Conducted
Add a test to capture if the warning does not exist when the attribute type is the same as the entry type.