### PR TITLE
Hook black include forte only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,4 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
+      files: ^forte/

--- a/ft/onto/base_ontology.py
+++ b/ft/onto/base_ontology.py
@@ -247,7 +247,6 @@ class PredicateArgument(Annotation):
         self.is_verb: Optional[bool] = None
 
 
-
 @dataclass
 class EntityMention(Annotation):
     """

--- a/ft/onto/base_ontology.py
+++ b/ft/onto/base_ontology.py
@@ -247,6 +247,7 @@ class PredicateArgument(Annotation):
         self.is_verb: Optional[bool] = None
 
 
+
 @dataclass
 class EntityMention(Annotation):
     """
@@ -340,7 +341,7 @@ class Dependency(Link):
 @dataclass
 class EnhancedDependency(Link):
     """
-    A `Link` type entry which represent a enhanced dependency: 
+    A `Link` type entry which represent a enhanced dependency:
      https://universaldependencies.org/u/overview/enhanced-syntax.html
     Attributes:
         dep_label (Optional[str]):	The enhanced dependency label in Universal Dependency.


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte/issues/883

### Description of changes
* under `.pre-commit-config.yaml`, for `black` check we only include files under `forte` folder. 

### Possible influences of this PR.
* it prevents black formatting on unexpected files such as `ft/onto/base_ontology.py` which is automatically generated from ontology system.

### Test Conducted
Describe what test cases are included for the PR.
